### PR TITLE
SetCurrentTextures checks if material == nullptr

### DIFF
--- a/Source/MaterialEditor.cpp
+++ b/Source/MaterialEditor.cpp
@@ -176,6 +176,8 @@ void MaterialEditor::TextureSelector(unsigned i, std::string &current_texture)
 
 void MaterialEditor::SetCurrentTextures()
 {
+	if (material == nullptr) return;
+
 	// Get material textures
 	Texture* diffuse_texture = material->GetTexture(TextureType::DIFFUSE);
 	Texture* specular_texture = material->GetTexture(TextureType::SPECULAR);


### PR DESCRIPTION
Prevents the app from breaking when new material is being created.