### PR TITLE
Console now auto scrolls to the end at the beggining of the execution

### DIFF
--- a/Source/PanelConsole.cpp
+++ b/Source/PanelConsole.cpp
@@ -52,6 +52,11 @@ void PanelConsole::Draw()
 	}
 
 	ScrollToBottom = false;
+	if (first)
+	{
+		ScrollToBottom = true;
+		first = false;
+	}
 	ImGui::EndChild();
 	ImGui::End();
 }

--- a/Source/PanelConsole.cpp
+++ b/Source/PanelConsole.cpp
@@ -52,10 +52,10 @@ void PanelConsole::Draw()
 	}
 
 	ScrollToBottom = false;
-	if (first)
+	if (ForceScrollToBottom)
 	{
 		ScrollToBottom = true;
-		first = false;
+		ForceScrollToBottom = false;
 	}
 	ImGui::EndChild();
 	ImGui::End();

--- a/Source/PanelConsole.cpp
+++ b/Source/PanelConsole.cpp
@@ -4,25 +4,25 @@
 
 PanelConsole::PanelConsole()
 {
-	Buf = new ImGuiTextBuffer();
+	buf = new ImGuiTextBuffer();
 }
 
 
 PanelConsole::~PanelConsole()
 {
-	RELEASE(Buf);
+	RELEASE(buf);
 }
 
 void PanelConsole::Clear()
 {
-	Buf->clear(); 
-	LineOffsets.clear();
+	buf->clear(); 
+	lineOffsets.clear();
 }
 
 void PanelConsole::AddLog(const char * log)
 {
-	Buf->appendf(log);
-	ScrollToBottom = true;
+	buf->appendf(log);
+	scrollToBottom = true;
 }
 
 void PanelConsole::Draw()
@@ -44,18 +44,18 @@ void PanelConsole::Draw()
 	ImGui::BeginChild("scrolling", ImVec2(0, 0), false, ImGuiWindowFlags_HorizontalScrollbar);
 	if (copy) ImGui::LogToClipboard();
 
-	ImGui::TextUnformatted(Buf->begin());
+	ImGui::TextUnformatted(buf->begin());
 
-	if (ScrollToBottom)
+	if (scrollToBottom)
 	{
 		ImGui::SetScrollHereY(1.0f);
 	}
 
-	ScrollToBottom = false;
-	if (ForceScrollToBottom)
+	scrollToBottom = false;
+	if (forceScrollToBottom)
 	{
-		ScrollToBottom = true;
-		ForceScrollToBottom = false;
+		scrollToBottom = true;
+		forceScrollToBottom = false;
 	}
 	ImGui::EndChild();
 	ImGui::End();

--- a/Source/PanelConsole.h
+++ b/Source/PanelConsole.h
@@ -17,10 +17,10 @@ public:
 	void Draw();
 
 private:
-	bool ForceScrollToBottom = true;
-	ImGuiTextBuffer* Buf = nullptr;
-	std::vector<int> LineOffsets;        // Index to lines offset
-	bool ScrollToBottom = false;
+	bool forceScrollToBottom = true;
+	ImGuiTextBuffer* buf = nullptr;
+	std::vector<int> lineOffsets;        // Index to lines offset
+	bool scrollToBottom = false;
 };
 
 #endif //__PanelConsole_h__

--- a/Source/PanelConsole.h
+++ b/Source/PanelConsole.h
@@ -17,7 +17,7 @@ public:
 	void Draw();
 
 private:
-	bool first = true;
+	bool ForceScrollToBottom = true;
 	ImGuiTextBuffer* Buf = nullptr;
 	std::vector<int> LineOffsets;        // Index to lines offset
 	bool ScrollToBottom = false;

--- a/Source/PanelConsole.h
+++ b/Source/PanelConsole.h
@@ -17,6 +17,7 @@ public:
 	void Draw();
 
 private:
+	bool first = true;
 	ImGuiTextBuffer* Buf = nullptr;
 	std::vector<int> LineOffsets;        // Index to lines offset
 	bool ScrollToBottom = false;


### PR DESCRIPTION
It already scrolled to the latest messages when new messages appeared, but not at the beginning of the execution. After some tests and research, turns out that is at the 2nd Update() loop that the console has to be scrolled down in order to work. And that's what I did.