### PR TITLE
Added play exception to drawProperties

### DIFF
--- a/Source/ComponentTransform.cpp
+++ b/Source/ComponentTransform.cpp
@@ -1,6 +1,7 @@
+#include "Application.h"
 #include "ComponentTransform.h"
-
 #include "GameObject.h"
+#include "ModuleTime.h"
 
 #include "imgui.h"
 #include "imgui_internal.h"
@@ -51,9 +52,10 @@ void ComponentTransform::AddTransform(const float4x4 & transform)
 
 void ComponentTransform::DrawProperties()
 {
+	
 	if (ImGui::CollapsingHeader("Local Transformation", ImGuiTreeNodeFlags_DefaultOpen))
 	{
-		if (gameobject->isStatic)
+		if (gameobject->isStatic && App->time->gameState != GameState::RUN)
 		{
 			ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
 			ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
@@ -69,7 +71,7 @@ void ComponentTransform::DrawProperties()
 		ImGui::DragFloat3("Scale", (float*)&scale, 0.1f, 0.01f, 100.f);
 		ImGui::Separator();
 
-		if (gameobject->isStatic)
+		if (gameobject->isStatic && App->time->gameState != GameState::RUN)
 		{
 			ImGui::PopItemFlag();
 			ImGui::PopStyleVar();

--- a/Source/Viewport.cpp
+++ b/Source/Viewport.cpp
@@ -4,6 +4,7 @@
 #include "ModuleScene.h"
 #include "ModuleInput.h"
 #include "ModuleTextures.h"
+#include "ModuleTime.h"
 
 #include "GameObject.h"
 #include "ComponentCamera.h"
@@ -295,7 +296,7 @@ void Viewport::DrawImGuizmo(const ComponentCamera & cam)
 	if (App->scene->selected != nullptr)
 	{
 
-		ImGuizmo::Enable(!App->scene->selected->isStatic);
+		ImGuizmo::Enable(!App->scene->selected->isStatic || App->time->gameState == GameState::RUN);
 
 		float4x4 model = App->scene->selected->GetGlobalTransform();
 		float4x4 view = cam.GetViewMatrix();


### PR DESCRIPTION
This takes care of being able to move Static objects during Play without changing the Static value on the GO.