### PR TITLE
now viewport exits draw function if the viewport is not visible

### DIFF
--- a/Source/Viewport.cpp
+++ b/Source/Viewport.cpp
@@ -56,6 +56,13 @@ void Viewport::Draw(ComponentCamera * cam, bool isEditor)
 	{
 		ImGui::Begin(name.c_str(), &enabled, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoBringToFrontOnFocus);
 
+		//if the viewport is hidden, it is not rendered
+		if (ImGui::GetCurrentWindow()->Hidden)
+		{
+			ImGui::End();
+			return;
+		}
+
 		if (ImGui::IsWindowHovered() || ImGui::IsWindowAppearing())
 		{
 			ImGui::SetWindowFocus();


### PR DESCRIPTION
Previous pull request had some errors and had to make a new one