### PR TITLE
Feature/clone components

### DIFF
--- a/Source/Component.h
+++ b/Source/Component.h
@@ -24,7 +24,7 @@ public:
 	
 	bool DrawComponentState();
 
-	virtual void DrawProperties() = 0;
+	virtual void DrawProperties(int id) = 0;
 	virtual void Enable()
 	{
 		enabled = true;

--- a/Source/Component.h
+++ b/Source/Component.h
@@ -41,6 +41,7 @@ public:
 		return true; 
 	}
 
+	virtual void Options() {}
 	void Remove();
 
 	virtual void Save(JSON_value* value) const;

--- a/Source/ComponentCamera.cpp
+++ b/Source/ComponentCamera.cpp
@@ -133,7 +133,7 @@ void ComponentCamera::Center() //TODO: Shouldn't be specfic to editor camera
 		{
 			float camDist = App->renderer->current_scale;
 			math::float3 center = ((ComponentTransform*)
-				(App->scene->selected->GetComponent(ComponentType::Transform)))->position;
+				(App->scene->selected->GetComponent(ComponentType::Transform)))->GetPosition();
 			frustum->pos = center + math::float3(0.0f, 0.0f, camDist);
 		}
 	}

--- a/Source/ComponentCamera.cpp
+++ b/Source/ComponentCamera.cpp
@@ -233,6 +233,9 @@ void ComponentCamera::DrawProperties(int id)
 			return;
 		}
 
+		ImGui::SameLine();
+		Options();
+
 		if (ImGui::Checkbox("Is Main Camera", &isMainCamera))
 		{
 			if (isMainCamera)
@@ -290,6 +293,47 @@ void ComponentCamera::Load(JSON_value* value)
 	frustum->pos = value->GetFloat3("Position");
 	frustum->front = value->GetFloat3("Front");
 	frustum->up = value->GetFloat3("Up");
+}
+
+void ComponentCamera::Options()
+{
+	ImGui::SetCursorPosX(ImGui::GetWindowWidth() - ImGui::CalcTextSize("Opt   ").x);
+	if (ImGui::Button("Opt"))
+	{
+		ImGui::OpenPopup("Options");
+	}
+
+	const char* options[] = { "Copy Component Values", "Paste Component Values", "Reset" };
+
+	if (ImGui::BeginPopup("Options"))
+	{
+		for (int i = 0; i < IM_ARRAYSIZE(options); i++)
+			if (ImGui::Selectable(options[i]))
+			{
+				if (i == 0) // Copy
+				{
+					App->scene->copyComp = Clone();
+				}
+				else if (i == 1) // Paste
+				{
+					if (App->scene->copyComp != nullptr && App->scene->copyComp->type == this->type)
+					{
+						ComponentCamera* comp = (ComponentCamera*)App->scene->copyComp;
+
+						frustum->verticalFov = comp->frustum->verticalFov;
+						frustum->farPlaneDistance = comp->frustum->farPlaneDistance;
+						frustum->nearPlaneDistance = comp->frustum->nearPlaneDistance;
+					}
+				}
+				else if (i == 2) // Reset
+				{
+					frustum->verticalFov = math::DegToRad(60.f);
+					frustum->farPlaneDistance = 100000.f;
+					frustum->nearPlaneDistance = 10.f;
+				}
+			}
+		ImGui::EndPopup();
+	}
 }
 
 float4x4 ComponentCamera::GetViewMatrix() const

--- a/Source/ComponentCamera.cpp
+++ b/Source/ComponentCamera.cpp
@@ -222,8 +222,9 @@ void ComponentCamera::Update()
 	frustum->up = transform.RotatePart().Mul(float3::unitY).Normalized();
 }
 
-void ComponentCamera::DrawProperties()
+void ComponentCamera::DrawProperties(int id)
 {
+	ImGui::PushID(id);
 	if (ImGui::CollapsingHeader("Camera", ImGuiTreeNodeFlags_DefaultOpen))
 	{
 		bool removed = Component::DrawComponentState();
@@ -258,6 +259,7 @@ void ComponentCamera::DrawProperties()
 
 		ImGui::Separator();
 	}
+	ImGui::PopID();
 }
 
 void ComponentCamera::Save(JSON_value* value) const

--- a/Source/ComponentCamera.h
+++ b/Source/ComponentCamera.h
@@ -17,7 +17,7 @@ public:
 	~ComponentCamera();
 
 	void Update() override;
-	void DrawProperties() override;
+	void DrawProperties(int id) override;
 	void Save(JSON_value* value) const override;
 	void Load(JSON_value* value) override;
 

--- a/Source/ComponentCamera.h
+++ b/Source/ComponentCamera.h
@@ -20,6 +20,7 @@ public:
 	void DrawProperties(int id) override;
 	void Save(JSON_value* value) const override;
 	void Load(JSON_value* value) override;
+	void Options() override;
 
 	ComponentCamera* Clone() const;
 	void Center();

--- a/Source/ComponentLight.cpp
+++ b/Source/ComponentLight.cpp
@@ -49,8 +49,9 @@ void ComponentLight::Update()
 	direction = -(gameobject->transform->rotation*float3::unitZ).Normalized();
 }
 
-void ComponentLight::DrawProperties()
+void ComponentLight::DrawProperties(int id)
 {
+	ImGui::PushID(id);
 	if (ImGui::CollapsingHeader("Light"))
 	{
 		bool removed = Component::DrawComponentState();
@@ -58,6 +59,10 @@ void ComponentLight::DrawProperties()
 		{
 			return;
 		}
+
+		ImGui::SameLine();
+		Options();
+
 		ImGui::Separator();
 		ImGui::Text("Type");
 		const char * types[] = {"Directional","Point", "Spot"};
@@ -95,6 +100,7 @@ void ComponentLight::DrawProperties()
 			ImGui::DragFloat("Outer", (float*)&outer, 0.1f, 0.f, 90.f);
 		}
 	}
+	ImGui::PopID();
 }
 
 void ComponentLight::DrawDebugLight() const
@@ -166,6 +172,42 @@ void ComponentLight::Save(JSON_value* value) const
 	{
 		value->AddFloat("inner", inner);
 		value->AddFloat("outer", outer);
+	}
+}
+
+void ComponentLight::Options()
+{
+	ImGui::SetCursorPosX(ImGui::GetWindowWidth() - ImGui::CalcTextSize("Opt   ").x);
+	if (ImGui::Button("Opt"))
+	{
+		ImGui::OpenPopup("Options");
+	}
+
+	const char* options[] = { "Copy Component Values", "Paste Component Values", "Reset" };
+
+	if (ImGui::BeginPopup("Options"))
+	{
+		for (int i = 0; i < IM_ARRAYSIZE(options); i++)
+			if (ImGui::Selectable(options[i]))
+			{
+				if (i == 0) // Copy
+				{
+					App->scene->copyComp = new ComponentLight(*this);
+				}
+				else if (i == 1) // Paste
+				{
+					if (App->scene->copyComp != nullptr && App->scene->copyComp->type == this->type)
+					{
+						ComponentLight* comp = (ComponentLight*)App->scene->copyComp;
+						
+					}
+				}
+				else if (i == 2) // Reset
+				{
+					
+				}
+			}
+		ImGui::EndPopup();
 	}
 }
 

--- a/Source/ComponentLight.cpp
+++ b/Source/ComponentLight.cpp
@@ -63,7 +63,7 @@ void ComponentLight::DrawProperties(int id)
 		ImGui::SameLine();
 		Options();
 
-		ImGui::Separator();
+		ImGui::Spacing();
 		ImGui::Text("Type");
 		const char * types[] = {"Directional","Point", "Spot"};
 		if (ImGui::BeginCombo("",types[(int)lightType]))
@@ -192,19 +192,27 @@ void ComponentLight::Options()
 			{
 				if (i == 0) // Copy
 				{
-					App->scene->copyComp = new ComponentLight(*this);
+					App->scene->copyComp = Clone();
 				}
 				else if (i == 1) // Paste
 				{
 					if (App->scene->copyComp != nullptr && App->scene->copyComp->type == this->type)
 					{
 						ComponentLight* comp = (ComponentLight*)App->scene->copyComp;
-						
+
+						lightType = comp->lightType;
+						color = comp->color;
+						attenuation = comp->attenuation;
+						inner = comp->inner;
+						outer = comp->outer;						
 					}
 				}
 				else if (i == 2) // Reset
 				{
-					
+					color = float3::one;
+					attenuation = float3(0.1f, 0.1f, 0.1f);
+					inner = 20.f;
+					outer = 25.f;
 				}
 			}
 		ImGui::EndPopup();

--- a/Source/ComponentLight.h
+++ b/Source/ComponentLight.h
@@ -26,10 +26,12 @@ public:
 	void ResetValues();
 
 	void Update() override;
-	void DrawProperties() override;
+	void DrawProperties(int id) override;
 	void DrawDebugLight() const;
+
 	void Load(JSON_value* value) override;
 	void Save(JSON_value* value) const override;
+	void Options() override;
 
 private:
 	void DrawDebugDirectional() const;

--- a/Source/ComponentRenderer.cpp
+++ b/Source/ComponentRenderer.cpp
@@ -44,9 +44,9 @@ Component * ComponentRenderer::Clone() const
 	return new ComponentRenderer(*this);
 }
 
-void ComponentRenderer::DrawProperties()
+void ComponentRenderer::DrawProperties(int id)
 {
-	ImGui::PushID(this);
+	ImGui::PushID(id);
 	if (ImGui::CollapsingHeader("Mesh Renderer", ImGuiTreeNodeFlags_DefaultOpen))
 	{
 		bool removed = Component::DrawComponentState();

--- a/Source/ComponentRenderer.h
+++ b/Source/ComponentRenderer.h
@@ -16,7 +16,7 @@ public:
 
 
 	Component* Clone() const override;
-	void DrawProperties() override;
+	void DrawProperties(int id) override;
 	bool CleanUp() override;
 
 	void Save(JSON_value* value) const override;

--- a/Source/ComponentScript.cpp
+++ b/Source/ComponentScript.cpp
@@ -36,8 +36,9 @@ ComponentScript * ComponentScript::Clone() const
 	return new ComponentScript(*this);
 }
 
-void ComponentScript::DrawProperties()
+void ComponentScript::DrawProperties(int id)
 {
+	ImGui::PushID(id);
 	if (ImGui::CollapsingHeader(scriptName.c_str(), ImGuiTreeNodeFlags_DefaultOpen))
 	{
 		bool removed = Component::DrawComponentState();
@@ -70,6 +71,7 @@ void ComponentScript::DrawProperties()
 			script->Expose(context);
 		}
 	}
+	ImGui::PopID();
 }
 
 void ComponentScript::Save(JSON_value* value) const

--- a/Source/ComponentScript.h
+++ b/Source/ComponentScript.h
@@ -16,7 +16,7 @@ public:
 	ComponentScript(const ComponentScript& component);
 	~ComponentScript();
 
-	void DrawProperties();
+	void DrawProperties(int id);
 	void Save(JSON_value* value) const override;
 	void Load(JSON_value* value) override;
 

--- a/Source/ComponentTransform.cpp
+++ b/Source/ComponentTransform.cpp
@@ -197,7 +197,7 @@ void ComponentTransform::Options()
 			{
 				if (i == 0) // Copy
 				{
-					App->scene->copyComp = new ComponentTransform(*this);
+					App->scene->copyComp = Clone();
 				}
 				else if (i == 1) // Paste
 				{

--- a/Source/ComponentTransform.cpp
+++ b/Source/ComponentTransform.cpp
@@ -51,8 +51,10 @@ void ComponentTransform::AddTransform(const math::float4x4& transform)
 	}
 }
 
-void ComponentTransform::DrawProperties()
+void ComponentTransform::DrawProperties(int id)
 {
+	ImGui::PushID(id);
+
 	if (ImGui::CollapsingHeader("Local Transformation", ImGuiTreeNodeFlags_DefaultOpen))
 	{
 		Options();
@@ -85,6 +87,7 @@ void ComponentTransform::DrawProperties()
 			gameobject->movedFlag = true;
 		}
 	}
+	ImGui::PopID();
 }
 
 void ComponentTransform::UpdateTransform()

--- a/Source/ComponentTransform.h
+++ b/Source/ComponentTransform.h
@@ -15,7 +15,7 @@ public:
 
 	Component* Clone() const override;
 	void AddTransform(const math::float4x4 &transform);
-	void DrawProperties() override;
+	void DrawProperties(int id) override;
 
 	void UpdateTransform();
 	void SetLocalToWorld();

--- a/Source/ComponentTransform.h
+++ b/Source/ComponentTransform.h
@@ -29,6 +29,7 @@ public:
 
 	void Save(JSON_value* value) const override;
 	void Load(JSON_value* value) override;
+	void Options() override;
 
 private:
 	void RotationToEuler();

--- a/Source/GameObject.cpp
+++ b/Source/GameObject.cpp
@@ -125,9 +125,11 @@ void GameObject::DrawProperties()
 		}
 	}
 
+	int i = 0;
 	for (auto &component : components)
 	{
-		component->DrawProperties();
+		component->DrawProperties(i);
+		i++;
 	}
 }
 

--- a/Source/ModuleScene.h
+++ b/Source/ModuleScene.h
@@ -84,6 +84,7 @@ private:
 public:
 	GameObject* root = nullptr;
 	GameObject* selected = nullptr; //Selected in hierarchy
+	Component* copyComp = nullptr; // Copied values in inspector
 	ComponentCamera* maincamera = nullptr; //Released by GameObject holding it
 	Texture* camera_notfound_texture = nullptr; //Released in resource manager
 	std::list<LineSegment> debuglines;


### PR DESCRIPTION
Components now can be cloned and reseted
- To clone a component, click on the options button and select "Clone Component Values"
- Add a new component of the same type to other gameObject
- Click on the options button and select "Paste Component Values"
- Try also to reset it

Enjoy 😄 