### PR TITLE
Added exception for canvas GO

### DIFF
--- a/Source/ModuleScene.cpp
+++ b/Source/ModuleScene.cpp
@@ -986,7 +986,7 @@ bool ModuleScene::AddScene(const char* scene, const char* path)
 	GameObject* parentGO = nullptr;
 	for (std::map<unsigned, GameObject*>::iterator it = gameobjectsMap.begin(); it != gameobjectsMap.end(); ++it)
 	{
-		if (it->second->parentUUID == 0u)
+		if (it->second->parentUUID == 0u && it->second->UUID != 1u)
 		{
 			parentGO = it->second;
 			break;


### PR DESCRIPTION
Bug happened because Canvas was mistakenly taken as the parent of all hierarchy since it's inserted in the AddScene and also has a parentUUID of 0. Now it's fixed