### PR TITLE
Added option to delete unused meta and imported files

### DIFF
--- a/Source/ModuleFileSystem.cpp
+++ b/Source/ModuleFileSystem.cpp
@@ -309,7 +309,7 @@ void ModuleFileSystem::ListFilesWithExtension(const char* dir, std::set<std::str
 			}
 			else
 			{
-				files.insert(dir + file);
+				files.insert(currentFolder + file);
 			}
 		}
 	}

--- a/Source/ModuleResourceManager.cpp
+++ b/Source/ModuleResourceManager.cpp
@@ -810,3 +810,26 @@ unsigned ModuleResourceManager::GetUIDFromMeta(const char* metaFile, FILETYPE fi
 	}	 
 	return value->GetUint("GUID");
 }
+
+void ModuleResourceManager::CleanUnusedMetaFiles() const
+{
+	// Get lists with all assets
+	std::set<std::string> assetFiles;
+	App->fsystem->ListFilesWithExtension(ASSETS, assetFiles);
+
+	for (auto& file : assetFiles)
+	{
+		if (HashString(App->fsystem->GetExtension(file).c_str()) == HashString(METAEXT))
+		{
+			std::string fileAssignedToMeta = App->fsystem->RemoveExtension(file);
+			if (!App->fsystem->Exists(fileAssignedToMeta.c_str()))
+			{
+				App->fsystem->Delete(file.c_str());
+			}
+		}
+	}
+}
+
+void ModuleResourceManager::CleanUnusedExportedFiles() const
+{
+}

--- a/Source/ModuleResourceManager.cpp
+++ b/Source/ModuleResourceManager.cpp
@@ -832,4 +832,15 @@ void ModuleResourceManager::CleanUnusedMetaFiles() const
 
 void ModuleResourceManager::CleanUnusedExportedFiles() const
 {
+	// Get lists with all imported files
+	std::set<std::string> importedFiles;
+	App->fsystem->ListFilesWithExtension(LIBRARY, importedFiles);
+
+	for (auto& file : importedFiles)
+	{
+		if (!App->resManager->Exists(file.c_str()))
+		{
+			App->fsystem->Delete(file.c_str());
+		}
+	}
 }

--- a/Source/ModuleResourceManager.h
+++ b/Source/ModuleResourceManager.h
@@ -77,6 +77,10 @@ class ModuleResourceManager :
 
 	unsigned GetUIDFromMeta(const char* metaFile, FILETYPE fileType) const;
 
+	// Clean functions
+	void CleanUnusedMetaFiles() const;			// Deletes all meta files that doesn't have a file assigned
+	void CleanUnusedExportedFiles() const;
+
 private:
 	// Resources map (Textures, Models, Mehses, Materials, Skyboxes, Scenes...)
 	std::map<unsigned, Resource*> resources;	// map<UID, pointer to resource>

--- a/Source/ModuleResourceManager.h
+++ b/Source/ModuleResourceManager.h
@@ -79,7 +79,7 @@ class ModuleResourceManager :
 
 	// Clean functions
 	void CleanUnusedMetaFiles() const;			// Deletes all meta files that doesn't have a file assigned
-	void CleanUnusedExportedFiles() const;
+	void CleanUnusedExportedFiles() const;		// Deletes all imported files that aren't registered on the Resource Manager
 
 private:
 	// Resources map (Textures, Models, Mehses, Materials, Skyboxes, Scenes...)

--- a/Source/PanelResourceManager.cpp
+++ b/Source/PanelResourceManager.cpp
@@ -96,7 +96,7 @@ void PanelResourceManager::Draw()
 			ImGui::EndMenu();
 		}
 
-		if (ImGui::BeginMenu("Clean Options"))
+		if (ImGui::BeginMenu("Options"))
 		{
 			if (ImGui::MenuItem("Delete Unused Metas"))
 			{

--- a/Source/PanelResourceManager.cpp
+++ b/Source/PanelResourceManager.cpp
@@ -80,11 +80,37 @@ PanelResourceManager::~PanelResourceManager()
 
 void PanelResourceManager::Draw()
 {
-	if (!ImGui::Begin("Resource Manager", &enabled))
+	if (!ImGui::Begin("Resource Manager", &enabled, ImGuiWindowFlags_MenuBar))
 	{
 		ImGui::End();
 		return;
 	}
+	if (ImGui::BeginMenuBar())
+	{
+		if (ImGui::BeginMenu("Resources"))
+		{
+			if (ImGui::MenuItem("Update Resources List"))
+			{
+				UpdateResourcesList();
+			}
+			ImGui::EndMenu();
+		}
+
+		if (ImGui::BeginMenu("Clean Options"))
+		{
+			if (ImGui::MenuItem("Delete Unused Metas"))
+			{
+				App->resManager->CleanUnusedMetaFiles();
+			}
+			if (ImGui::MenuItem("Delete Unused Library Files"))
+			{
+
+			}
+			ImGui::EndMenu();
+		}
+		ImGui::EndMenuBar();
+	}
+
 	if(auxResource == nullptr)
 		UpdateResourcesList();
 

--- a/Source/PanelResourceManager.cpp
+++ b/Source/PanelResourceManager.cpp
@@ -102,9 +102,9 @@ void PanelResourceManager::Draw()
 			{
 				App->resManager->CleanUnusedMetaFiles();
 			}
-			if (ImGui::MenuItem("Delete Unused Library Files"))
+			if (ImGui::MenuItem("Delete Unused Exported Files"))
 			{
-
+				App->resManager->CleanUnusedExportedFiles();
 			}
 			ImGui::EndMenu();
 		}


### PR DESCRIPTION
Inside PanelResourceManager there is a new menu bar, inside "Options" there are 2 options:
- **Delete Unused Metas:** Will look for every orphan meta and delete it.
- **Delete Unused Exported Files:** Will look for every exported file that isn't registered inside the RM and delete it.

To test that it works:
- Open the Engine.
- Once all assets have been imported close it.
- Now change the name of a material inside Assets/Materials.
- Open the engine.
- Take a look at the number of meta files inside Assets/Materials (there should be 12 material files and 13 metas).
- Take a look at the number of files inside Library/Materials (there should be more than 12 files).
- Open the PanelResourceManager (Tools->Resource Manager) inside the engine.
- Go to Options in the menu bar and choose Delete Unused Metas.
- Now look at Assets/Materials, there should be 12 material files and 12 meta files.
- Inside the engine again: Go to Options in the menu bar and choose Delete Unused Exported Files.
- Now look at Library/Materials, there should be 12 files.