### PR TITLE
Toggle billboard + custom particle orientation

### DIFF
--- a/Source/ComponentParticles.cpp
+++ b/Source/ComponentParticles.cpp
@@ -172,7 +172,7 @@ void ComponentParticles::DrawProperties()
 			ImGui::Separator();
 		}
 		ImGui::InputInt("Max Particles", &maxParticles);
-		ImGui::DragFloat("Rate", &rate, 0.1f, 0.1f, 1000000.f);
+		ImGui::DragFloat("Rate", &rate, 0.1f, 0.1f, MAX_RATE);
 
 		ImGui::Text("Particle properties:");
 		ImGui::Checkbox("Billboarded", &billboarded);

--- a/Source/ComponentParticles.h
+++ b/Source/ComponentParticles.h
@@ -1,6 +1,7 @@
 #ifndef __ComponentParticles_h__
 #define __ComponentParticles_h__
 
+#define MAX_DISTANCE 10000000.f
 #include "Component.h"
 #include <string>
 #include "Math/float3.h"
@@ -101,7 +102,7 @@ private:
 	float rateTimer = 1.f / rate;
 	int maxParticles = 50;
 	math::float2 particleSize = math::float2(1.f * App->renderer->current_scale, 1.f * App->renderer->current_scale) ;
-	float quadEmitterSize = 10.f * App->renderer->current_scale;
+	math::float2 quadEmitterSize = math::float2(10.f * App->renderer->current_scale);
 	float sphereEmitterRadius = 5.f * App->renderer->current_scale;
 	math::float4 particleColor = math::float4::one;
 	math::float3 pDir = math::float3(-1.f, 0.f, 0.f);
@@ -120,6 +121,9 @@ private:
 
 	bool ConstantPlaying = true;
 	bool Playing = false;
+
+	bool billboarded = true;
+	math::float3 lookAtTarget = math::float3::unitY;
 
 };
 

--- a/Source/ModuleParticles.cpp
+++ b/Source/ModuleParticles.cpp
@@ -275,12 +275,23 @@ void ModuleParticles::DrawParticleSystem(ComponentParticles* cp, const Component
 	glBindVertexArray(billBoardVAO);
 	glBindBuffer(GL_ARRAY_BUFFER, billBoardInstanceVBO);
 	float* matrices = (float*)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
-
-	cp->particles.sort(
-		[camera](const Particle* cp1, const Particle* cp2) -> bool
+	if (cp->billboarded)
 	{
-		return cp1->position.Distance(camera->frustum->pos) > cp2->position.Distance(camera->frustum->pos);
-	});
+		cp->particles.sort(
+			[camera](const Particle* cp1, const Particle* cp2) -> bool
+		{
+			return cp1->position.Distance(camera->frustum->pos) > cp2->position.Distance(camera->frustum->pos);
+		});
+	}
+	else
+	{
+		math::float3 orderPoint = cp->gameobject->transform->position + cp->lookAtTarget * MAX_DISTANCE;
+		cp->particles.sort(
+			[orderPoint](const Particle* cp1, const Particle* cp2) -> bool
+		{
+			return cp1->position.Distance(orderPoint) > cp2->position.Distance(orderPoint);
+		});
+	}
 
 	unsigned nParticles = cp->particles.size();
 	for (; nParticles > 0; --nParticles)


### PR DESCRIPTION
Now the particles could be billboarded or aligned to an axis.

To test:

- Create particle system
- In the component toggle billboarded check
- Try different values to the lookAt vector. By default aligns in the world Y axis.