### PR TITLE
Add behaviour on disable

### DIFF
--- a/Source/ComponentBoxTrigger.cpp
+++ b/Source/ComponentBoxTrigger.cpp
@@ -75,12 +75,23 @@ void ComponentBoxTrigger::DrawProperties()
 	ImGui::PushID(this);
 	if (ImGui::CollapsingHeader("Box Trigger", ImGuiTreeNodeFlags_DefaultOpen))
 	{
-		bool removed = Component::DrawComponentState();
+		bool active = enabled;
+
+		ImGui::Checkbox("Active", &active); ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Button, (ImVec4)ImColor::HSV(0.f, 0.6f, 0.6f));
+		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, (ImVec4)ImColor::HSV(0.f / 7.0f, 0.7f, 0.7f));
+		ImGui::PushStyleColor(ImGuiCol_ButtonActive, (ImVec4)ImColor::HSV(0.f / 7.0f, 0.8f, 0.8f));
+
+		bool removed = ImGui::Button("Remove");
+		if (removed) Remove();
+		ImGui::PopStyleColor(3);
+
 		if (removed)
 		{
 			ImGui::PopID();
 			return;
 		}
+		if (active != enabled) Enable(active);
 
 		ImGui::Checkbox("Draw Debug Box", &debugDraw);
 
@@ -158,6 +169,28 @@ void ComponentBoxTrigger::Update()
 
 void ComponentBoxTrigger::OnPlay()
 {
+	overlapList.clear();
+}
+
+void ComponentBoxTrigger::OnDisable()
+{
+	for (auto it = overlapList.begin(); it != overlapList.end(); ++it)
+	{
+		switch (it->second)
+		{
+		case OverlapState::Enter:
+		case OverlapState::Exit:
+			break;
+
+		case OverlapState::Idle:
+		case OverlapState::PostIdle:
+			PropagateState(it->first->gameobject, OverlapState::Exit);
+			break;
+
+		default:
+			break;
+		}
+	}
 	overlapList.clear();
 }
 

--- a/Source/ComponentBoxTrigger.cpp
+++ b/Source/ComponentBoxTrigger.cpp
@@ -198,6 +198,18 @@ void ComponentBoxTrigger::OnDisable()
 	overlapList.clear();
 }
 
+void ComponentBoxTrigger::OnEnable()
+{
+	boxTrigger->axis[0] = gameobject->transform->right.Normalized();
+	boxTrigger->axis[1] = gameobject->transform->up.Normalized();
+	boxTrigger->axis[2] = gameobject->transform->front.Normalized();
+
+	boxTrigger->pos = gameobject->transform->global.MulPos(position);
+	boxTrigger->r.x = size.x * gameobject->transform->right.Length();
+	boxTrigger->r.y = size.y * gameobject->transform->up.Length();
+	boxTrigger->r.z = size.z * gameobject->transform->front.Length();
+}
+
 void ComponentBoxTrigger::DrawDebug()
 {
 	ddVec3* corners = new ddVec3[8];

--- a/Source/ComponentBoxTrigger.cpp
+++ b/Source/ComponentBoxTrigger.cpp
@@ -128,10 +128,14 @@ void ComponentBoxTrigger::DrawProperties()
 void ComponentBoxTrigger::Update()
 {
 	if (!enabled) return;
-	boxTrigger->axis[0] = gameobject->transform->right;
-	boxTrigger->axis[1] = gameobject->transform->up;
-	boxTrigger->axis[2] = gameobject->transform->front;
+	boxTrigger->axis[0] = gameobject->transform->right.Normalized();
+	boxTrigger->axis[1] = gameobject->transform->up.Normalized();
+	boxTrigger->axis[2] = gameobject->transform->front.Normalized();
+	
 	boxTrigger->pos = gameobject->transform->global.MulPos(position);
+	boxTrigger->r.x = size.x * gameobject->transform->right.Length();
+	boxTrigger->r.y = size.y * gameobject->transform->up.Length();
+	boxTrigger->r.z = size.z * gameobject->transform->front.Length();
 
 	std::vector<const ComponentBoxTrigger*> toRemove;
 	for (auto it = overlapList.begin(); it != overlapList.end(); ++it)

--- a/Source/ComponentBoxTrigger.h
+++ b/Source/ComponentBoxTrigger.h
@@ -27,6 +27,7 @@ public:
 
 	virtual void Update() override;
 	virtual void OnPlay() override;
+	virtual void OnDisable() override;
 	void DrawDebug();
 
 	void SetIsPlayer(bool isPlayer);

--- a/Source/ComponentBoxTrigger.h
+++ b/Source/ComponentBoxTrigger.h
@@ -28,6 +28,8 @@ public:
 	virtual void Update() override;
 	virtual void OnPlay() override;
 	virtual void OnDisable() override;
+	virtual void OnEnable() override;
+
 	void DrawDebug();
 
 	void SetIsPlayer(bool isPlayer);

--- a/Source/ModuleCollisions.cpp
+++ b/Source/ModuleCollisions.cpp
@@ -7,9 +7,13 @@ update_status ModuleCollisions::Update(float dt)
 {
 	for (auto player : playerBoxes)
 	{
+		if (!player->enabled) continue;
+
 		const math::OBB* player_obb = player->GetOBB();
 		for (auto other : otherBoxes)
 		{
+			if (!other->enabled) continue;
+
 			const math::OBB* other_obb = other->GetOBB();
 			if (player_obb->Intersects(*other_obb))
 			{


### PR DESCRIPTION
**Expected behaviors:**
- Disabled components do not raise triggers
- Properly detects overlap and acts accordingly after being enabled/disabled
  - if we disable a BoxTrigger Component, it raises "OnTriggerExit()" on itself and all overlapping boxes of the opposite category.  
    - _MUST USE "Enable()" function to work properly! (modifying the enabled attribute directly avoid raising "OnTriggerExit()" on itself._
  - Enabling a disabled BoxTrigger raises "OnTriggerEnter()" on itself and all overlapping boxed of the opposite category (if there are any overlaps)
