### PR TITLE
Now default node is only used at PlayPress

### DIFF
--- a/Source/ComponentAnimation.cpp
+++ b/Source/ComponentAnimation.cpp
@@ -308,6 +308,7 @@ void ComponentAnimation::SetStateMachine(const char* stateMachineFile)
 	{
 		stateMachine = (ResourceStateMachine*)App->resManager->GetByName(stateMachineFile, TYPE::STATEMACHINE);
 		strcpy(newStMachineName, stateMachine->GetName());
+		currentNode = stateMachine->GetDefaultNode();
 	}
 }
 
@@ -317,11 +318,12 @@ void ComponentAnimation::SendTriggerToStateMachine(const char* trigger)
 	{	
 		if (controller->CanSwitch())
 		{
-			unsigned prevNode = stateMachine->GetDefaultNode();
+			unsigned prevNode = currentNode;
 			float blend = 0.f;
 
-			stateMachine->ReceiveTrigger(HashString(trigger), blend);
-			if (prevNode != stateMachine->GetDefaultNode())
+			stateMachine->ReceiveTrigger(HashString(trigger), blend, currentNode);
+
+			if (prevNode != currentNode)
 			{
 				SetIndexChannels(gameobject, GetAnimFromStateMachine());
 				PlayNextNode(blend);
@@ -332,8 +334,7 @@ void ComponentAnimation::SendTriggerToStateMachine(const char* trigger)
 
 ResourceAnimation* ComponentAnimation::GetAnimFromStateMachine()
 {
-	unsigned nodeIndex = stateMachine->GetDefaultNode();
-	HashString clipName = stateMachine->GetNodeClip(nodeIndex);
+	HashString clipName = stateMachine->GetNodeClip(currentNode);
 	unsigned clipIndex = stateMachine->FindClip(clipName);
 	unsigned animUID = stateMachine->GetClipResource(clipIndex);
 	ResourceAnimation*  resAnim = (ResourceAnimation*)(App->resManager->Get(animUID));
@@ -342,22 +343,19 @@ ResourceAnimation* ComponentAnimation::GetAnimFromStateMachine()
 
 bool ComponentAnimation::GetLoopFromStateMachine()
 {
-	unsigned nodeIndex = stateMachine->GetDefaultNode();
-	HashString clipName = stateMachine->GetNodeClip(nodeIndex);
+	HashString clipName = stateMachine->GetNodeClip(currentNode);
 	return stateMachine->GetClipLoop(stateMachine->FindClip(clipName));
 }
 
 float ComponentAnimation::GetSpeedFromStateMachine()
 {
-	unsigned nodeIndex = stateMachine->GetDefaultNode();
-	HashString clipName = stateMachine->GetNodeClip(nodeIndex);
+	HashString clipName = stateMachine->GetNodeClip(currentNode);
 	return stateMachine->GetClipSpeed(stateMachine->FindClip(clipName));
 }
 
 bool ComponentAnimation::GetMustFinishFromStateMachine()
 {
-	unsigned nodeIndex = stateMachine->GetDefaultNode();
-	HashString clipName = stateMachine->GetNodeClip(nodeIndex);
+	HashString clipName = stateMachine->GetNodeClip(currentNode);
 	return stateMachine->GetClipMustFinish(stateMachine->FindClip(clipName));
 }
 

--- a/Source/ComponentAnimation.h
+++ b/Source/ComponentAnimation.h
@@ -60,6 +60,7 @@ public:
 	bool channelsSetted = false;
 	bool deletePopup = false;
 
+	unsigned currentNode = 0u;
 
 public:
 	AnimationController* editorController = nullptr;

--- a/Source/PanelState.cpp
+++ b/Source/PanelState.cpp
@@ -150,7 +150,6 @@ void PanelState::DrawTransitions(ResourceStateMachine * stateMachine)
 		if (origin < numNodes && destiny < numNodes)
 		{
 			ed::Link(numNodes * 3 + i + 1, origin * 3 + 3, destiny * 3 + 2);
-			stateMachine->Save();
 		}
 	}
 	ed::PopStyleVar(1);

--- a/Source/ResourceStateMachine.cpp
+++ b/Source/ResourceStateMachine.cpp
@@ -342,17 +342,17 @@ void ResourceStateMachine::Save()
 
 void ResourceStateMachine::AddClip(const HashString name, unsigned UID, const bool loop)
 {
-	clips.push_back(Clip(name, UID, loop, false, 1.0f));
+	clips.emplace_back(name, UID, loop, false, 1.0f);
 }
 
 void ResourceStateMachine::AddNode(const HashString name, const HashString clipName)
 {
-	nodes.push_back(Node(name, clipName));
+	nodes.emplace_back(name, clipName);
 }
 
 void ResourceStateMachine::AddTransition(const HashString origin, const HashString destiny, const HashString trigger, unsigned blend)
 {
-	transitions.push_back(Transition(origin, destiny, trigger, blend));
+	transitions.emplace_back(origin, destiny, trigger, blend);
 }
 
 unsigned ResourceStateMachine::FindClip(const HashString name)
@@ -578,15 +578,15 @@ void ResourceStateMachine::RemoveTransition(unsigned index)
 	transitions.erase(transitions.begin() + index);
 }
 
-void ResourceStateMachine::ReceiveTrigger(HashString trigger, float &blend)
+void ResourceStateMachine::ReceiveTrigger(HashString trigger, float &blend, unsigned &node)
 {
-	HashString defaultNodeName = GetNodeName(defaultNode);
+	HashString currentNodeName = GetNodeName(node);
 
 	for (auto& trans : transitions)
 	{
-		if (trans.origin == defaultNodeName && trans.trigger == trigger)
+		if (trans.origin == currentNodeName && trans.trigger == trigger)
 		{
-			defaultNode = FindNode(trans.destiny);
+			node = FindNode(trans.destiny);
 			blend = trans.blend;
 			break;
 		}

--- a/Source/ResourceStateMachine.h
+++ b/Source/ResourceStateMachine.h
@@ -77,7 +77,7 @@ public:
 	void RemoveNode(unsigned UID);
 	void RemoveTransition(unsigned UID);
 
-	void ReceiveTrigger(HashString trigger, float &blend);
+	void ReceiveTrigger(HashString trigger, float &blend, unsigned &node);
 
 	bool isClipsEmpty() { return clips.empty(); }
 	bool isNodesEmpty() { return nodes.empty(); }


### PR DESCRIPTION
Now defaultNode is only used when Play is pressed, after that the variable is stored inside the component Animation enabling different entities to share a SM resource without bugging out.
CurrentNode is also resetted everytime so it takes care of that as well.