### PR TITLE
Removed unecessary check in debugnavmesh and Modified scene drawing order

### DIFF
--- a/Source/ModuleNavigation.cpp
+++ b/Source/ModuleNavigation.cpp
@@ -323,7 +323,7 @@ void ModuleNavigation::navigableObjectToggled(GameObject* obj, const bool newSta
 
 void ModuleNavigation::renderNavMesh()
 {
-	if (!meshGenerated || !renderMesh || autoNavGeneration || !drawNavMesh || navMesh == nullptr)
+	if (!meshGenerated || !renderMesh || !drawNavMesh || navMesh == nullptr)
 	{
 		return;
 	}

--- a/Source/ModuleNavigation.cpp
+++ b/Source/ModuleNavigation.cpp
@@ -323,7 +323,7 @@ void ModuleNavigation::navigableObjectToggled(GameObject* obj, const bool newSta
 
 void ModuleNavigation::renderNavMesh()
 {
-	if (!meshGenerated || !renderMesh || !drawNavMesh || navMesh == nullptr)
+	if (!meshGenerated || !renderMesh || !autoNavGeneration || !drawNavMesh || navMesh == nullptr)
 	{
 		return;
 	}

--- a/Source/ModuleRender.cpp
+++ b/Source/ModuleRender.cpp
@@ -253,12 +253,15 @@ void ModuleRender::Draw(const ComponentCamera &cam, int width, int height, bool 
 	SetProjectionUniform(cam);
 	SetViewUniform(cam);
 
+	App->scene->Draw(*cam.frustum, isEditor);
+	App->particles->Render(App->time->gameDeltaTime, &cam);
+
 	if (isEditor)
 	{
 		DrawGizmos(cam);
+		skybox->Draw(*cam.frustum, true);
 		App->navigation->renderNavMesh();
 		glUseProgram(0);
-		skybox->Draw(*cam.frustum, true);
 
 	}
 	else 
@@ -269,9 +272,7 @@ void ModuleRender::Draw(const ComponentCamera &cam, int width, int height, bool 
 		glClearBufferfv(GL_COLOR, 2, transparent);
 	}
 	
-	App->scene->Draw(*cam.frustum, isEditor);
 
-	App->particles->Render(App->time->gameDeltaTime, &cam);
 	
 	if (!isEditor)
 	{

--- a/Source/ModuleRender.cpp
+++ b/Source/ModuleRender.cpp
@@ -253,16 +253,10 @@ void ModuleRender::Draw(const ComponentCamera &cam, int width, int height, bool 
 	SetProjectionUniform(cam);
 	SetViewUniform(cam);
 
-	App->scene->Draw(*cam.frustum, isEditor);
-	App->particles->Render(App->time->gameDeltaTime, &cam);
-
 	if (isEditor)
 	{
 		DrawGizmos(cam);
 		skybox->Draw(*cam.frustum, true);
-		App->navigation->renderNavMesh();
-		glUseProgram(0);
-
 	}
 	else 
 	{
@@ -272,6 +266,8 @@ void ModuleRender::Draw(const ComponentCamera &cam, int width, int height, bool 
 		glClearBufferfv(GL_COLOR, 2, transparent);
 	}
 	
+	App->scene->Draw(*cam.frustum, isEditor);
+	App->particles->Render(App->time->gameDeltaTime, &cam);
 
 	
 	if (!isEditor)
@@ -317,6 +313,10 @@ void ModuleRender::Draw(const ComponentCamera &cam, int width, int height, bool 
 		glUseProgram(0);
 
 		glActiveTexture(GL_TEXTURE0); //LOL without this the skybox doesn't render
+	}
+	else
+	{
+		App->navigation->renderNavMesh();
 	}
 
 	if (!isEditor || isEditor && App->ui->showUIinSceneViewport)


### PR DESCRIPTION
- Now debug nav mesh appears in scene window, you can disable it in the navigation tab
- Checkout if objects are correctly displayed
- Checkout that particles are correctly rendered.