### PR TITLE
Now animated meshes can be shared between the same animated model

### DIFF
--- a/Source/ComponentRenderer.cpp
+++ b/Source/ComponentRenderer.cpp
@@ -1,4 +1,5 @@
 #include "Application.h"
+#include "GL/glew.h"
 
 #include "ModuleResourceManager.h"
 #include "ModuleFileSystem.h"
@@ -17,6 +18,7 @@
 #include "JSON.h"
 #include "HashString.h"
 
+#include <stack>
 #include "imgui.h"
 #include "Math/float4x4.h"
 
@@ -295,7 +297,78 @@ void ComponentRenderer::UpdateGameObject()
 	}
 }
 
-void ComponentRenderer::LinkBones() const
+void ComponentRenderer::LinkBones()
 {
-	mesh->LinkBones(gameobject);
+	bindBones.clear();
+	bindBones = mesh->bindBones;
+
+	if (bindBones.size() == 0)
+	{
+		return;
+	}
+	unsigned linkedCount = 0u;
+
+	for (unsigned i = 0u; i < bindBones.size(); ++i)
+	{
+		GameObject* node = gameobject;
+		while (node != nullptr && !node->isBoneRoot)
+		{
+			node = node->parent;
+		}
+
+		if (node == nullptr)
+		{
+			return;
+		}
+
+		bool found = false;
+
+		std::stack<GameObject*> S;
+		S.push(node);
+
+		while (!S.empty() && !found)
+		{
+			node = S.top();
+			S.pop();
+			if (node->name == bindBones[i].name)
+			{
+				found = true;
+				bindBones[i].go = node;
+				++linkedCount;
+			}
+			else
+			{
+				for (GameObject* go : node->children)
+				{
+					S.push(go);
+				}
+			}
+		}
+	}
+
+	LOG("Linked %d bones from %s", linkedCount, gameobject->name.c_str());
+
+}
+
+void ComponentRenderer::DrawMesh(unsigned shaderProgram)
+{
+	if (bindBones.size() > 0)
+	{
+		std::vector<math::float4x4> palette(bindBones.size(), math::float4x4::identity); //TODO: Declare on .h
+		unsigned i = 0u;
+		for (BindBone bb : bindBones)
+		{
+			palette[i++] = bb.go->GetGlobalTransform() * bb.transform;
+		}
+
+		glUniformMatrix4fv(glGetUniformLocation(shaderProgram,
+			"palette"), bindBones.size(), GL_TRUE, palette[0].ptr());
+	}
+
+	glBindVertexArray(mesh->VAO);
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh->EBO);
+	glDrawElements(GL_TRIANGLES, mesh->meshIndices.size(), GL_UNSIGNED_INT, 0);
+
+	// We disable VAO
+	glBindVertexArray(0);
 }

--- a/Source/ComponentRenderer.h
+++ b/Source/ComponentRenderer.h
@@ -6,6 +6,7 @@
 
 class ResourceMesh;
 class ResourceMaterial;
+struct BindBone;
 
 class ComponentRenderer :
 	public Component
@@ -26,7 +27,9 @@ public:
 	ENGINE_API void SetMaterial(const char* materialName);
 	void SetMesh(const char* meshfile);
 	void UpdateGameObject();
-	void LinkBones() const;
+	void LinkBones();
+
+	void DrawMesh(unsigned shaderProgram);
 
 public:
 	ResourceMesh* mesh = nullptr;
@@ -39,6 +42,8 @@ public:
 private:
 	std::vector<std::string> guiMaterials;
 	std::vector<std::string> guiMeshes;
+
+	std::vector<BindBone> bindBones;
 };
 
 #endif __ComponentRenderer_h__

--- a/Source/ModuleRender.cpp
+++ b/Source/ModuleRender.cpp
@@ -655,7 +655,7 @@ void ModuleRender::BlitShadowTexture()
 			"viewProjection"), 1, GL_TRUE, &shadowsFrustum.ViewProjMatrix()[0][0]);
 		glUniformMatrix4fv(glGetUniformLocation(shadowsShader->id[variation],
 			"model"), 1, GL_TRUE, &cr->gameobject->GetGlobalTransform()[0][0]);
-		cr->mesh->Draw(shadowsShader->id[variation]);
+		cr->DrawMesh(shadowsShader->id[variation]);
 	}
 
 	glUseProgram(0);

--- a/Source/ModuleScene.cpp
+++ b/Source/ModuleScene.cpp
@@ -419,7 +419,7 @@ void ModuleScene::DrawGOGame(const GameObject& go)
 	go.SetLightUniforms(shader->id[variation]);
 
 	go.UpdateModel(shader->id[variation]);
-	crenderer->mesh->Draw(shader->id[variation]);
+	crenderer->DrawMesh(shader->id[variation]);
 
 	glBindTexture(GL_TEXTURE_2D, 0);
 	glActiveTexture(GL_TEXTURE0);
@@ -488,7 +488,7 @@ void ModuleScene::DrawGO(const GameObject& go, const Frustum & frustum, bool isE
 	}
 	if (mesh != nullptr)
 	{
-		crenderer->mesh->Draw(shader->id[variation]);
+		crenderer->DrawMesh(shader->id[variation]);
 	}
 	
 

--- a/Source/ResourceMesh.h
+++ b/Source/ResourceMesh.h
@@ -67,14 +67,14 @@ private:
 	void SetBboxBuffers();
 
 public:
-	unsigned VAO = 0;
-	unsigned VBO = 0;
-	unsigned EBO = 0;
+	unsigned VAO = 0u;
+	unsigned VBO = 0u;
+	unsigned EBO = 0u;
 
 	AABB boundingBox;
-	unsigned VAObox = 0;
-	unsigned VBObox = 0;
-	unsigned EBObox = 0;
+	unsigned VAObox = 0u;
+	unsigned VBObox = 0u;
+	unsigned EBObox = 0u;
 
 
 	

--- a/Source/ResourceMesh.h
+++ b/Source/ResourceMesh.h
@@ -13,6 +13,24 @@
 class ComponentRenderer;
 class GameObject;
 
+
+struct BindBone
+{
+	math::float4x4 transform; //Transforms from mesh space to bone space
+	std::string name;
+	GameObject* go = nullptr;
+};
+
+struct BoneVertex
+{
+	int boneID[MAX_WEIGHTS_PER_BONE] = { 0, 0, 0, 0 };
+};
+
+struct BoneWeight
+{
+	float weight[MAX_WEIGHTS_PER_BONE] = { 0.f, 0.f, 0.f, 0.f };
+};
+
 class ResourceMesh : public Resource
 {
 public:
@@ -41,25 +59,6 @@ public:
 	void Delete() override;
 
 private:
-
-	struct BindBone
-	{
-		math::float4x4 transform; //Transforms from mesh space to bone space
-		std::string name;
-		GameObject* go = nullptr;
-	};
-
-	struct BoneVertex
-	{
-		int boneID[MAX_WEIGHTS_PER_BONE] = { 0, 0, 0, 0 };
-	};
-
-	struct BoneWeight
-	{
-		float weight[MAX_WEIGHTS_PER_BONE] = { 0.f, 0.f, 0.f, 0.f };
-	};
-
-private:
 	void ComputeBBox();
 	void ProcessVertexTangent(const float vIndex1, const float vIndex2, const float vIndex3);
 	void CalculateTangents();
@@ -67,7 +66,7 @@ private:
 	void SetMeshBuffers();
 	void SetBboxBuffers();
 
-private:
+public:
 	unsigned VAO = 0;
 	unsigned VBO = 0;
 	unsigned EBO = 0;


### PR DESCRIPTION
To test just use the "Add scene" command to add the same mesh with animations, i.e. the small enemy, Zombunny, player, etc. Press play and enjoy.

Make sure that a state machine is assigned to the root of the model!