### PR TITLE
Is possible to enable the text wrapping in the component text

### DIFF
--- a/Source/ComponentText.cpp
+++ b/Source/ComponentText.cpp
@@ -8,6 +8,8 @@
 #include <vector>
 #define MAX_TEXT_LENGTH 64
 #define MAX_FONT_SIZE 64
+#define MAX_WRAP_WIDTH 10000
+#define MAX_INTERLINE_DISTANCE 10000
 
 Text::Text() : Component(nullptr, ComponentType::Text)
 {
@@ -28,6 +30,9 @@ Text::Text(const Text &copy) : Component(copy)
 	colorHovered = copy.colorHovered;
 	offset = copy.offset;
 	scaleOffset = copy.scaleOffset;
+	isTextWrapped = copy.isTextWrapped;
+	wrapWidth = copy.wrapWidth;
+	interlineDistance = copy.interlineDistance;
 }
 
 Text::~Text()
@@ -83,6 +88,12 @@ void Text::DrawProperties()
 		ImGui::ColorEdit4("Font color highlited", (float*)&colorHovered);
 		ImGui::DragFloat2("Text position offset", &offset[0]);
 		ImGui::DragFloat2("Text scale offset", &scaleOffset[0]);
+		ImGui::Checkbox("Wrap text", &isTextWrapped);
+		if (isTextWrapped)
+		{
+			ImGui::DragFloat("Wrap width", &wrapWidth, 1.0f, 1.0f, MAX_WRAP_WIDTH);
+			ImGui::DragFloat("Interline Distance", &interlineDistance, 1.0f, 1.0f, MAX_INTERLINE_DISTANCE);
+		}
 		ImGui::Separator();
 	}
 }
@@ -97,6 +108,9 @@ void Text::Save(JSON_value *value)const
 	value->AddFloat4("colorHovered", colorHovered);
 	value->AddFloat2("offset", offset);
 	value->AddFloat2("scaleOffset", scaleOffset);
+	value->AddInt("IsTextWrapped", isTextWrapped);
+	value->AddFloat("WrapWidth", wrapWidth);
+	value->AddFloat("InterlineDistance", interlineDistance);
 }
 
 void Text::Load(JSON_value* value)
@@ -109,4 +123,7 @@ void Text::Load(JSON_value* value)
 	colorHovered = value->GetFloat4("colorHovered");
 	offset = value->GetFloat2("offset");
 	scaleOffset = value->GetFloat2("scaleOffset");
+	isTextWrapped = value->GetInt("IsTextWrapped");
+	wrapWidth = value->GetFloat("WrapWidth");
+	interlineDistance = value->GetFloat("InterlineDistance");
 }

--- a/Source/ComponentText.h
+++ b/Source/ComponentText.h
@@ -20,7 +20,7 @@ public:
 	void Save(JSON_value* value) const override;
 	void Load(JSON_value* value) override;
 public:
-	float fontSize = 14;
+	float fontSize = 64;
 	std::string text = "Fractal Text";
 	std::string font = "";
 	math::float4 color = math::float4(1.0f, 1.0f, 1.0f, 0.0f);
@@ -28,6 +28,9 @@ public:
 	math::float2 offset = math::float2::zero;
 	math::float2 scaleOffset = math::float2::one;
 	bool isHovered = false;
+	bool isTextWrapped = false;
+	float wrapWidth = 100;
+	float interlineDistance = 24;
 };
 
 #endif


### PR DESCRIPTION
In this PR is implemented the text wrapping, steps to test it:

- Recompile everything.
- Add camera and change to game window
- Create a text component, right click on canvas -> UI -> text
- Enable text wrapping

**Expected result:**

https://cdn.discordapp.com/attachments/584767898459832321/589774338635595786/UI-TEXT_WRAPPING_V1.0.gif
