### PR TITLE
Feature/hit pause

### DIFF
--- a/Source/ModuleTime.cpp
+++ b/Source/ModuleTime.cpp
@@ -1,6 +1,9 @@
 #include "ModuleTime.h"
+#include "Math/MathFunc.h"
 
 #define MAX_FRAME_MS 0.04F
+#define NORMAL_SPEED 1.0f
+#define FREEZE 0.0f
 
 ModuleTime::ModuleTime()
 {
@@ -28,8 +31,23 @@ void ModuleTime::UpdateTime()
 	realTime += realDeltaTime;
 
 	++totalFrames;
-	gameDeltaTime = frameTimer.ReadSeconds();
-	fullGameDeltaTime = gameDeltaTime;
+	gameDeltaTime = realDeltaTime;
+
+	if (temporaryFreeze)
+	{
+		freezeTimer += realDeltaTime;
+		if (freezeTimer >= freezeDuration)
+		{
+			UnFreezeGame();
+		}
+		else
+		{
+			HandleFreeze();
+		}
+	}
+
+	//Gamedeltatime is partitioned if it is too high
+	fullGameDeltaTime = gameDeltaTime * gameTimeScale;
 
 	gameTime += gameDeltaTime * gameTimeScale;
 	
@@ -43,6 +61,7 @@ void ModuleTime::UpdateTime()
 		fpsTimer.Reset();
 	}
 
+	gameDeltaTime *= gameTimeScale;
 	if (gameDeltaTime > MAX_FRAME_MS)
 	{
 		PartitionTime();
@@ -51,7 +70,6 @@ void ModuleTime::UpdateTime()
 	{
 		isTimePartitioned = false;
 	}
-	gameDeltaTime *= gameTimeScale;
 }
 
 void ModuleTime::ResetGameDetaTime()
@@ -124,4 +142,43 @@ void ModuleTime::StopGameClock()
 void ModuleTime::Step() 
 {
 	nextFrame = true;
+}
+
+void ModuleTime::FreezeGame(float duration, float fadeInTime, float fadeOutTime, bool linealFade)
+{
+	temporaryFreeze = true;
+	freezeDuration = duration;
+	freezeFadeIn = fadeInTime;
+	freezeFadeOut = fadeOutTime;
+	this->linealFade = linealFade;
+	freezeTimer = 0.0f;
+	gameTimeScale = FREEZE;
+}
+
+void ModuleTime::UnFreezeGame()
+{
+	temporaryFreeze = false;
+	gameTimeScale = NORMAL_SPEED;
+}
+
+void ModuleTime::HandleFreeze()
+{
+	if (freezeTimer < freezeFadeIn * freezeDuration)
+	{
+		gameTimeScale = Lerp(NORMAL_SPEED, FREEZE, freezeTimer / (freezeFadeIn * freezeDuration));
+		if (!linealFade)
+		{
+			gameTimeScale = SmoothStep(FREEZE, NORMAL_SPEED, gameTimeScale);
+		}
+	}
+	else if (freezeTimer >= freezeFadeOut * freezeDuration)
+	{
+		float fadeOutTime = (1 - freezeFadeOut) * freezeDuration;
+		gameTimeScale = Lerp(FREEZE, NORMAL_SPEED, 
+			(freezeTimer - freezeFadeOut * freezeDuration) / fadeOutTime);
+		if (!linealFade)
+		{
+			gameTimeScale = SmoothStep(FREEZE, NORMAL_SPEED, gameTimeScale);
+		}
+	}
 }

--- a/Source/ModuleTime.h
+++ b/Source/ModuleTime.h
@@ -31,8 +31,12 @@ public:
 	void StopGameClock();
 	void Step();
 
-	ENGINE_API void UnFreezeGame();
+	/** @param fadeInTime value between [0,1].
+	@@ param fadeOutTime value between [0,1].
+	Represents percentage of freeze time that fadeIn ends and fadeOut starts
+	fadeIn value of 0.0f is not fadeIn, same with FadeOut and value 1.0f**/
 	ENGINE_API void FreezeGame(float duration, float fadeInTime = 0.0f, float fadeOutTime = 1.0f, bool linealFade = false);
+	ENGINE_API void UnFreezeGame();
 
 private:
 	void HandleFreeze();

--- a/Source/ModuleTime.h
+++ b/Source/ModuleTime.h
@@ -31,12 +31,24 @@ public:
 	void StopGameClock();
 	void Step();
 
+	ENGINE_API void UnFreezeGame();
+	ENGINE_API void FreezeGame(float duration, float fadeInTime = 0.0f, float fadeOutTime = 1.0f, bool linealFade = false);
+
 private:
+	void HandleFreeze();
 	void PartitionTime();
 
 private:
 	unsigned frameCount = 0u;
 	float aggregateGameDeltaTime = 0.0f;
+
+	//Freeze
+	bool temporaryFreeze = false;
+	float freezeTimer = 0.0f;
+	float freezeDuration = 0.0f;
+	float freezeFadeIn = 0.0f;
+	float freezeFadeOut = 0.0f;
+	bool linealFade = false;
 
 public:
 	int FPS = 0;


### PR DESCRIPTION
# Le Feature

- I've created a method in the moduleTime exposed to scripts that allows to freeze time. In your script you only have to call once this method.

```cpp
FreezeGame(float duration, float fadeInTime = 0.0f, float fadeOutTime = 1.0f, bool linealFade = false);
```
![hitStop](https://user-images.githubusercontent.com/25633904/59786482-a40d6800-92c7-11e9-8ae1-ce96a1d0e7cb.gif)

- You can se the duration of the freeze. You can also set a time for fading from real time to freeze, you can also create cool *SlowMo* effects with that.

![slowmo](https://user-images.githubusercontent.com/25633904/59786497-abcd0c80-92c7-11e9-91c0-725d81b00cfb.gif)

- We use a non linear interpolation like in the shake screen method but you can set it to linear if you set the _linearFade_ boolean to true.

- If you want to end the _Freeze_ before the duration  manually you can call the method _UnFreezeGame()_.

## Le Test

- Test in any script the _FreezeGame_ method with our without fading.
- You can also try to _UnFreeze_ before the duration of _FreezeGame_ is over.