### PR TITLE
PanelResourceManager sorting bug fixed

### DIFF
--- a/Source/PanelResourceManager.cpp
+++ b/Source/PanelResourceManager.cpp
@@ -151,13 +151,13 @@ void PanelResourceManager::Draw()
 	ImGui::Columns(7);
 	// Table references: UID | File | Exported File | References | Type |
 	ImGui::PushStyleColor(ImGuiCol_Text, (ImVec4)ImColor::HSV(0.0f, 1.0f, 1.0f));
-	if (ImGui::Selectable("UID"))			{ if (sortList == SORTING::UID) descending = !descending; sortList = SORTING::UID; }				ImGui::SameLine(); ImGui::NextColumn();
-	if (ImGui::Selectable("Name"))			{ if (sortList == SORTING::NAME) descending = !descending; sortList = SORTING::NAME; }				ImGui::SameLine(); ImGui::NextColumn();
-	if (ImGui::Selectable("File"))			{ if (sortList == SORTING::FILE) descending = !descending; sortList = SORTING::FILE;}				ImGui::SameLine(); ImGui::NextColumn();
-	if (ImGui::Selectable("Exported File"))	{ if (sortList == SORTING::EXPORTED) descending = !descending; sortList = SORTING::EXPORTED;}		ImGui::SameLine(); ImGui::NextColumn();
-	if (ImGui::Selectable("References"))	{ if (sortList == SORTING::REFERENCES) descending = !descending; sortList = SORTING::REFERENCES;}	ImGui::SameLine(); ImGui::NextColumn();
-	if (ImGui::Selectable("Type"))			{ if (sortList == SORTING::TYPE) descending = !descending; sortList = SORTING::TYPE;}				ImGui::SameLine(); ImGui::NextColumn();
-	ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "");																						ImGui::NextColumn(); ImGui::Separator();
+	if (ImGui::Selectable("UID"))			{ if (sortList == SORTING::UID) descending = !descending; sortList = SORTING::UID; 				UpdateResourcesList();}	ImGui::SameLine(); ImGui::NextColumn();
+	if (ImGui::Selectable("Name")) { if (sortList == SORTING::NAME) descending = !descending; sortList = SORTING::NAME; 					UpdateResourcesList();}	ImGui::SameLine(); ImGui::NextColumn();
+	if (ImGui::Selectable("File"))			{ if (sortList == SORTING::FILE) descending = !descending; sortList = SORTING::FILE;			UpdateResourcesList();} ImGui::SameLine(); ImGui::NextColumn();
+	if (ImGui::Selectable("Exported File"))	{ if (sortList == SORTING::EXPORTED) descending = !descending; sortList = SORTING::EXPORTED;	UpdateResourcesList();}	ImGui::SameLine(); ImGui::NextColumn();
+	if (ImGui::Selectable("References"))	{ if (sortList == SORTING::REFERENCES) descending = !descending; sortList = SORTING::REFERENCES;UpdateResourcesList();}	ImGui::SameLine(); ImGui::NextColumn();
+	if (ImGui::Selectable("Type"))			{ if (sortList == SORTING::TYPE) descending = !descending; sortList = SORTING::TYPE;			UpdateResourcesList();}	ImGui::SameLine(); ImGui::NextColumn();
+	ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "");																											ImGui::NextColumn(); ImGui::Separator();
 	ImGui::PopStyleColor(1);
 
 	for each (auto& resource in resourcesList)


### PR DESCRIPTION
Bug: When clicking on a column title (name, UID, File...) of the PanelResourceManager the list wasn't updated. You needed to update it from the menu.

Fix: Now it is updated automatically.

To test: 
- Open the PanelResourceManager from MainMenuBar->Tools->ResourceManager
- Click on any column title and check if the list is sorted by that variable.

https://gyazo.com/c6cab1b67f89adfc9361546d70c89c2f