### PR TITLE
New DeleteJson method + DeleteAll also deletes jsons

### DIFF
--- a/Source/JSON.h
+++ b/Source/JSON.h
@@ -55,13 +55,13 @@ private:
 class JSON
 {
 public:
-	JSON();
+	ENGINE_API JSON();
 	JSON(const char * data);
 	~JSON();
 
-	JSON_value* CreateValue(rapidjson::Type type = rapidjson::kObjectType);
-	void AddValue(const char * name, const JSON_value & value);
-	JSON_value * GetValue(const char * name);  //Allocates value
+	ENGINE_API JSON_value* CreateValue(rapidjson::Type type = rapidjson::kObjectType);
+	ENGINE_API void AddValue(const char * name, const JSON_value & value);
+	ENGINE_API JSON_value * GetValue(const char * name);  //Allocates value
 	std::string ToString() const;
 	unsigned Size(); //Clears old buffer
 

--- a/Source/PlayerPrefs.cpp
+++ b/Source/PlayerPrefs.cpp
@@ -9,9 +9,16 @@
 std::map<const char*, int, ltstr> PlayerPrefs::integers;
 std::map<const char*, float, ltstr> PlayerPrefs::floats;
 std::map<const char*, const char*, ltstr> PlayerPrefs::strings;
+bool PlayerPrefs::hasPrefsFile;
 
 void PlayerPrefs::Save()
 {
+	if (integers.empty() && floats.empty() && strings.empty() && hasPrefsFile)
+	{
+		App->fsystem->Delete(PREFSFILE PREFS);
+		hasPrefsFile = false;
+		return;
+	}
 	unsigned totalSize = GetMapSize(integers) + GetMapSize(floats) + GetMapSize(strings);
 	char *buffer = new char[totalSize];
 	char* cursor = buffer;
@@ -30,6 +37,7 @@ void PlayerPrefs::Load()
 	unsigned size = App->fsystem->Load(PREFSFILE PREFS, &data);
 	if (size > 0)
 	{
+		hasPrefsFile = true;
 		char* cursor = data;
 		DeSerializeMap(integers, &cursor);
 		DeSerializeMap(floats, &cursor);
@@ -86,11 +94,20 @@ void PlayerPrefs::DeleteKey(const char* key)
 	if (Delete(strings, key)) return;
 }
 
-void PlayerPrefs::DeleteAll()
+void PlayerPrefs::DeleteAll(bool deleteJsons)
 {
 	CleanMap(integers);
 	CleanMap(floats);
 	CleanMap(strings);
+	if (deleteJsons)
+	{
+		std::set<std::string> files;
+		App->fsystem->ListFileNames(PERSISTENCE, files);
+		for (const auto& file : files)
+		{
+			DeleteJson(file.c_str());
+		}
+	}
 }
 
 JSON* PlayerPrefs::LoadJson(const char * file)
@@ -116,4 +133,12 @@ bool PlayerPrefs::SaveJson(JSON * json, const char* filename)
 	filepath += filename;
 	filepath += PREFS;
 	return App->fsystem->Save(filepath.c_str(), json->ToString().c_str(), json->Size());
+}
+
+void PlayerPrefs::DeleteJson(const char * file)
+{
+	std::string filepath(PERSISTENCE);
+	filepath += file;
+	filepath += PREFS;
+	App->fsystem->Delete(filepath.c_str());
 }

--- a/Source/PlayerPrefs.h
+++ b/Source/PlayerPrefs.h
@@ -31,10 +31,11 @@ public:
 	static bool			HasKey(const char* key);
 
 	static void			DeleteKey(const char* key);
-	static void			DeleteAll();
+	static void			DeleteAll(bool deleteJsons = false); //flag also deletes all json files saved
 
 	static JSON*		LoadJson(const char* file);
 	static bool			SaveJson(JSON* json, const char* filename);
+	static void			DeleteJson(const char* file);
 
 private:
 
@@ -78,6 +79,7 @@ private:
 	static std::map<const char*, int, ltstr> integers;
 	static std::map<const char*, float, ltstr> floats;
 	static std::map<const char*, const char*, ltstr> strings;
+	static bool hasPrefsFile;
 };
 
 template<class T>


### PR DESCRIPTION
# Feature

- New _DeleteJson_ method. Now you can delete _JSON_'s created from _PlayerPrefs_ directly calling this method.
- _DeleteAll_ has a flag that allows to delete all _PlayerPrefs_ _JSON_'s.
- When _PlayerPrefs_ is empty there is no longer an empty file created.

## Test
- Create and save a _JSON_ with _PlayerPrefs::SaveJson()_ and then delete it with the new method.
- Try to the same again but delete it using the _PlayerPrefs::DeleteAll(true)_ 
- Delete all PlayerPrefs variables saved and watch if the _player.prefs_ file from the Persistence folder is deleted too