### PR TITLE
Toggle UI menus

### DIFF
--- a/Scripts/GameLoop/LoopStateControls.cpp
+++ b/Scripts/GameLoop/LoopStateControls.cpp
@@ -19,7 +19,7 @@ void LoopStateControls::Update()
 	if (gLoop->backControlsButton->IsPressed())
 	{
 		gLoop->backControlsButton->isHovered = false;
-		gLoop->backControlsButton->isKeyDown = false;
+		//gLoop->backControlsButton->isKeyDown = false;
 		gLoop->controls->SetActive(false);
 		gLoop->EnableMenuButtons(true);
 		gLoop->currentLoopState = (LoopState*)gLoop->menuState;

--- a/Scripts/GameLoop/LoopStateOptions.cpp
+++ b/Scripts/GameLoop/LoopStateOptions.cpp
@@ -24,7 +24,7 @@ void LoopStateOptions::Update()
 	if (gLoop->backOptionButton->IsPressed())
 	{
 		gLoop->backOptionButton->isHovered = false;
-		gLoop->backOptionButton->isKeyDown = false;
+		//gLoop->backOptionButton->isKeyDown = false;
 		gLoop->options->SetActive(false);
 		gLoop->EnableMenuButtons(true);
 		gLoop->currentLoopState = (LoopState*)gLoop->menuState;

--- a/Scripts/GameLoop/LoopStatePlaying.cpp
+++ b/Scripts/GameLoop/LoopStatePlaying.cpp
@@ -23,11 +23,11 @@ LoopStatePlaying::~LoopStatePlaying()
 
 void LoopStatePlaying::HandleHotkeys()
 {
-	if (gLoop->App->input->GetKey(SDL_SCANCODE_ESCAPE) == KEY_DOWN)
+	/*if (gLoop->App->input->GetKey(SDL_SCANCODE_ESCAPE) == KEY_DOWN)
 	{
 		gLoop->closePlayerMenuButton->isKeyUp = true;
 	}
-	else if (gLoop->App->input->GetKey(SDL_SCANCODE_B) == KEY_DOWN)
+	else if ()
 	{
 		gLoop->inventoryButton->isKeyDown = true;
 	}
@@ -42,56 +42,32 @@ void LoopStatePlaying::HandleHotkeys()
 	else if (gLoop->App->input->GetKey(SDL_SCANCODE_M) == KEY_DOWN)
 	{
 		//This will open the map
-	}
+	}*/
 }
 
 void LoopStatePlaying::Update()
 {
-	HandleHotkeys();
+	if (gLoop->hudBackToMenuButton->IsPressed()) LoadMainMenu();
 
-	if (gLoop->hudBackToMenuButton->IsPressed())
+	if (gLoop->closePlayerMenuButton->KeyUp()) CloseMenu();
+	if (gLoop->playerMenuGO->isActive() && gLoop->App->input->GetKey(SDL_SCANCODE_ESCAPE) == KEY_DOWN) CloseMenu();
+
+	if (gLoop->inventoryButton->IsPressed() || gLoop->App->input->GetKey(SDL_SCANCODE_B) == KEY_DOWN)
 	{
-		gLoop->currentLoopState = (LoopState*)gLoop->loadingState;
-		gLoop->playerMenuGO->SetActive(false);
-		gLoop->hudGO->SetActive(false);
-		gLoop->loadingGO->SetActive(true);
-		gLoop->sceneToLoad = MENU_SCENE;
+		if (gLoop->inventoryMenuGO->isActive()) CloseMenu();
+		else OpenMenu(gLoop->inventoryMenuGO);
 	}
 
-	if (gLoop->closePlayerMenuButton->KeyUp())
+	if (gLoop->skillsButton->IsPressed() || gLoop->App->input->GetKey(SDL_SCANCODE_V) == KEY_DOWN)
 	{
-		gLoop->closePlayerMenuButton->isHovered = false;
-		gLoop->playerMenuGO->SetActive(false);
-		gLoop->inventoryButton->rectTransform->setPosition(math::float2(-50, gLoop->inventoryButton->rectTransform->getPosition().y));
-		gLoop->skillsButton->rectTransform->setPosition(math::float2(-50, gLoop->skillsButton->rectTransform->getPosition().y));
-		gLoop->missionsButton->rectTransform->setPosition(math::float2(-50, gLoop->missionsButton->rectTransform->getPosition().y));
-
+		if (gLoop->skillsMenuGO->isActive()) CloseMenu();
+		else OpenMenu(gLoop->skillsMenuGO);
 	}
 
-	if (gLoop->inventoryButton->IsPressed() || gLoop->skillsButton->IsPressed() || gLoop->missionsButton->IsPressed())
+	if (gLoop->missionsButton->IsPressed() || gLoop->App->input->GetKey(SDL_SCANCODE_N) == KEY_DOWN)
 	{
-		bool alreadyOpen =  (gLoop->inventoryButton->IsPressed() && gLoop->inventoryMenuGO->isActive()) ||
-							(gLoop->skillsButton->IsPressed() && gLoop->skillsMenuGO->isActive()) ||
-							(gLoop->missionsButton->IsPressed() && gLoop->missionsMenuGO->isActive());
-		
-		if ((alreadyOpen && gLoop->playerMenuGO->isActive()))
-		{
-			gLoop->closePlayerMenuButton->isHovered = false;
-			gLoop->playerMenuGO->SetActive(false);
-			gLoop->inventoryButton->rectTransform->setPosition(math::float2(-50, gLoop->inventoryButton->rectTransform->getPosition().y));
-			gLoop->skillsButton->rectTransform->setPosition(math::float2(-50, gLoop->skillsButton->rectTransform->getPosition().y));
-			gLoop->missionsButton->rectTransform->setPosition(math::float2(-50, gLoop->missionsButton->rectTransform->getPosition().y));
-		}
-		else
-		{
-			gLoop->playerMenuGO->SetActive(true);
-			gLoop->inventoryButton->rectTransform->setPosition(math::float2(-485, gLoop->inventoryButton->rectTransform->getPosition().y));
-			gLoop->skillsButton->rectTransform->setPosition(math::float2(-485, gLoop->skillsButton->rectTransform->getPosition().y));
-			gLoop->missionsButton->rectTransform->setPosition(math::float2(-485, gLoop->missionsButton->rectTransform->getPosition().y));
-			gLoop->inventoryMenuGO->SetActive(gLoop->inventoryButton->IsPressed());
-			gLoop->skillsMenuGO->SetActive(gLoop->skillsButton->IsPressed());
-			gLoop->missionsMenuGO->SetActive(gLoop->missionsButton->IsPressed());
-		}
+		if (gLoop->missionsMenuGO->isActive()) CloseMenu();
+		else OpenMenu(gLoop->missionsMenuGO);
 	}
 
 	if (gLoop->playerScript->isPlayerDead)
@@ -104,4 +80,40 @@ void LoopStatePlaying::Update()
 		gLoop->winWindow->SetActive(true);
 		gLoop->currentLoopState = (LoopState*)gLoop->winState;
 	}
+}
+
+void LoopStatePlaying::LoadMainMenu()
+{
+	gLoop->currentLoopState = (LoopState*)gLoop->loadingState;
+	gLoop->playerMenuGO->SetActive(false);
+	gLoop->hudGO->SetActive(false);
+	gLoop->loadingGO->SetActive(true);
+	gLoop->sceneToLoad = MENU_SCENE;
+}
+
+void LoopStatePlaying::OpenMenu(GameObject * menu)
+{
+	gLoop->playerMenuGO->SetActive(true);
+	
+	gLoop->inventoryButton->rectTransform->setPosition(math::float2(-485, gLoop->inventoryButton->rectTransform->getPosition().y));
+	gLoop->skillsButton->rectTransform->setPosition(math::float2(-485, gLoop->skillsButton->rectTransform->getPosition().y));
+	gLoop->missionsButton->rectTransform->setPosition(math::float2(-485, gLoop->missionsButton->rectTransform->getPosition().y));
+	
+	gLoop->inventoryMenuGO->SetActive(menu == gLoop->inventoryMenuGO);
+	gLoop->skillsMenuGO->SetActive(   menu == gLoop->skillsMenuGO);
+	gLoop->missionsMenuGO->SetActive( menu == gLoop->missionsMenuGO);
+}
+
+void LoopStatePlaying::CloseMenu()
+{
+	gLoop->closePlayerMenuButton->isHovered = false;
+
+	gLoop->inventoryMenuGO->SetActive(false);
+	gLoop->skillsMenuGO->SetActive(false);
+	gLoop->missionsMenuGO->SetActive(false);
+	gLoop->playerMenuGO->SetActive(false);
+
+	gLoop->inventoryButton->rectTransform->setPosition(math::float2(-50, gLoop->inventoryButton->rectTransform->getPosition().y));
+	gLoop->skillsButton->rectTransform->setPosition(math::float2(-50, gLoop->skillsButton->rectTransform->getPosition().y));
+	gLoop->missionsButton->rectTransform->setPosition(math::float2(-50, gLoop->missionsButton->rectTransform->getPosition().y));
 }

--- a/Scripts/GameLoop/LoopStatePlaying.cpp
+++ b/Scripts/GameLoop/LoopStatePlaying.cpp
@@ -70,13 +70,28 @@ void LoopStatePlaying::Update()
 
 	if (gLoop->inventoryButton->IsPressed() || gLoop->skillsButton->IsPressed() || gLoop->missionsButton->IsPressed())
 	{
-		gLoop->playerMenuGO->SetActive(true);
-		gLoop->inventoryButton->rectTransform->setPosition(math::float2(-485, gLoop->inventoryButton->rectTransform->getPosition().y));
-		gLoop->skillsButton->rectTransform->setPosition(math::float2(-485, gLoop->skillsButton->rectTransform->getPosition().y));
-		gLoop->missionsButton->rectTransform->setPosition(math::float2(-485, gLoop->missionsButton->rectTransform->getPosition().y));
-		gLoop->inventoryMenuGO->SetActive(gLoop->inventoryButton->IsPressed());
-		gLoop->skillsMenuGO->SetActive(gLoop->skillsButton->IsPressed());
-		gLoop->missionsMenuGO->SetActive(gLoop->missionsButton->IsPressed());
+		bool alreadyOpen =  (gLoop->inventoryButton->IsPressed() && gLoop->inventoryMenuGO->isActive()) ||
+							(gLoop->skillsButton->IsPressed() && gLoop->skillsMenuGO->isActive()) ||
+							(gLoop->missionsButton->IsPressed() && gLoop->missionsMenuGO->isActive());
+		
+		if ((alreadyOpen && gLoop->playerMenuGO->isActive()))
+		{
+			gLoop->closePlayerMenuButton->isHovered = false;
+			gLoop->playerMenuGO->SetActive(false);
+			gLoop->inventoryButton->rectTransform->setPosition(math::float2(-50, gLoop->inventoryButton->rectTransform->getPosition().y));
+			gLoop->skillsButton->rectTransform->setPosition(math::float2(-50, gLoop->skillsButton->rectTransform->getPosition().y));
+			gLoop->missionsButton->rectTransform->setPosition(math::float2(-50, gLoop->missionsButton->rectTransform->getPosition().y));
+		}
+		else
+		{
+			gLoop->playerMenuGO->SetActive(true);
+			gLoop->inventoryButton->rectTransform->setPosition(math::float2(-485, gLoop->inventoryButton->rectTransform->getPosition().y));
+			gLoop->skillsButton->rectTransform->setPosition(math::float2(-485, gLoop->skillsButton->rectTransform->getPosition().y));
+			gLoop->missionsButton->rectTransform->setPosition(math::float2(-485, gLoop->missionsButton->rectTransform->getPosition().y));
+			gLoop->inventoryMenuGO->SetActive(gLoop->inventoryButton->IsPressed());
+			gLoop->skillsMenuGO->SetActive(gLoop->skillsButton->IsPressed());
+			gLoop->missionsMenuGO->SetActive(gLoop->missionsButton->IsPressed());
+		}
 	}
 
 	if (gLoop->playerScript->isPlayerDead)

--- a/Scripts/GameLoop/LoopStatePlaying.h
+++ b/Scripts/GameLoop/LoopStatePlaying.h
@@ -15,6 +15,11 @@ public:
 	void HandleHotkeys();
 
 	void Update() override;
+
+private:
+	void LoadMainMenu();
+	void OpenMenu(GameObject* menu);
+	void CloseMenu();
 };
 
 #endif // __LOOPSTATEPLAYING_H_

--- a/Source/ComponentButton.cpp
+++ b/Source/ComponentButton.cpp
@@ -133,6 +133,12 @@ void Button::Load(JSON_value* value)
 
 void Button::Update()
 {
+	if (isKeyDown)
+	{
+		isPressed = true;
+		isKeyDown = false;
+	}
+
 	math::float2 mouse = reinterpret_cast<const float2&>(App->input->GetMousePosition());	
 	float screenX = mouse.x - App->renderer->viewGame->winPos.x - (App->ui->currentWidth * .5f);
 	float screenY = mouse.y - App->renderer->viewGame->winPos.y - (App->ui->currentHeight * .5f);
@@ -164,24 +170,26 @@ void Button::Update()
 		text->isHovered = false;
 	}
 
-	if (isKeyDown && !isHovered)
+	if (isPressed && !isHovered)
 	{
-		isKeyDown = false;
+		isPressed = false;
 		pressedImage->enabled = false;
 
 	}
 
 	isKeyUp = false;
-	if (isHovered && isKeyDown && App->input->GetMouseButtonDown(1) == KEY_UP)
+	if (isHovered && isPressed && App->input->GetMouseButtonDown(1) == KEY_UP)
 	{
 		isKeyUp = true;
-		isKeyDown = false;
+		isPressed = false;
 		pressedImage->enabled = false;
 	}
 
 	if (isHovered && App->input->GetMouseButtonDown(1) == KEY_DOWN)
 	{
 		isKeyDown = true;
+		isPressed = false;
+
 		buttonImage->enabled = false;
 		highlightedImage->enabled = false;
 		pressedImage->enabled = true;
@@ -192,6 +200,7 @@ void Button::Enable(bool enable)
 {
 	Component::Enable(enable);
 	isKeyDown = false;
+	isPressed = false;
 	isKeyUp = false;
 	isHovered = false;
 	isSelected = false;

--- a/Source/ComponentButton.h
+++ b/Source/ComponentButton.h
@@ -8,6 +8,13 @@ class Text;
 class Transform2D;
 class ResourceTexture;
 
+enum class ButtonState
+{
+	NONE = 0,
+	DOWN,
+	REPEAT,
+	UP
+};
 
 class Button :	public Component
 {
@@ -27,10 +34,10 @@ public:
 	void AssemblyButton();
 
 	ENGINE_API inline bool IsHovered() { return isHovered; };
-	ENGINE_API inline bool IsPressed() { return isKeyDown; };
+	ENGINE_API inline bool IsPressed() { return state == ButtonState::DOWN; };
 
-	ENGINE_API inline bool KeyUp()	 { return isKeyUp; }
-	ENGINE_API inline bool KeyDown() { return isKeyDown; }
+	ENGINE_API inline bool KeyUp()	 { return state == ButtonState::UP; }
+	ENGINE_API inline bool KeyDown() { return state == ButtonState::DOWN; }
 
 	ENGINE_API void UpdateImageByName(std::string name);
 	ENGINE_API void UpdateImageByResource(ResourceTexture* name);
@@ -46,9 +53,7 @@ public:
 	bool isHovered = false;
 	bool isSelected = false;
 
-	bool isKeyDown = false;
-	bool isPressed = false;
-	bool isKeyUp = false;
+	ButtonState state = ButtonState::NONE;
 
 	bool hoverDetectionMouse1 = true;
 	bool hoverDetectionMouse3 = true;

--- a/Source/ComponentButton.h
+++ b/Source/ComponentButton.h
@@ -8,6 +8,7 @@ class Text;
 class Transform2D;
 class ResourceTexture;
 
+
 class Button :	public Component
 {
 public:
@@ -44,7 +45,9 @@ public:
 
 	bool isHovered = false;
 	bool isSelected = false;
+
 	bool isKeyDown = false;
+	bool isPressed = false;
 	bool isKeyUp = false;
 
 	bool hoverDetectionMouse1 = true;


### PR DESCRIPTION
- Changed ComponentButton interaction detection from flags to states
- Revamped Playing GameLoop to manage toogling menus on or off 

Behaviour:
- Button opens its menu if the menu is closed, 
- Button closes its menu if the menu is open

Test:
Try opening and closing menus

![ToogleMenus](https://user-images.githubusercontent.com/26639060/60112420-0c4cc580-9770-11e9-91e4-7d4120772d0f.gif)