### PR TITLE
Undefine max and min functions in rapidjson dependencies

### DIFF
--- a/Source/rapidjson-1.1.0/include/rapidjson/document.h
+++ b/Source/rapidjson-1.1.0/include/rapidjson/document.h
@@ -24,6 +24,8 @@
 #include "encodedstream.h"
 #include <new>      // placement new
 #include <limits>
+#undef min
+#undef max
 
 RAPIDJSON_DIAG_PUSH
 #ifdef _MSC_VER


### PR DESCRIPTION
# Le Bug
- In order to avoid compile errors I've undefined _min_ and _max_ functions used in document.h

## Le Test
- Compile & Test you can load and save scenes properly 😃 