### PR TITLE
Circular attack bug fixed

### DIFF
--- a/Scripts/PlayerMovement/CircularAttackSkill.cpp
+++ b/Scripts/PlayerMovement/CircularAttackSkill.cpp
@@ -27,7 +27,9 @@ CircularAttackSkill::~CircularAttackSkill()
 
 void CircularAttackSkill::Start()
 {
-	fullSpinTime = player->currentState->duration;
+	fullSpinTime = duration;
+
+	LOG("Spin time: %f", fullSpinTime);
 
 	MeleeSkill::Start();
 
@@ -47,7 +49,9 @@ void CircularAttackSkill::Update()
 
 	timer += player->App->time->gameDeltaTime;
 
-	if (timer < player->currentState->duration * numSpins)
+	LOG("TIMER: %f", timer);
+
+	if (timer < fullSpinTime * numSpins)
 	{
 		UseSkill();
 	}
@@ -104,6 +108,7 @@ void CircularAttackSkill::UseSkill()
 		else
 		{
 			spinTimer += player->App->time->gameDeltaTime;
+			LOG("Spin Timer: %f", spinTimer);
 		}
 	}
 	else if(atatckStarted)
@@ -154,7 +159,7 @@ void CircularAttackSkill::Reset()
 void CircularAttackSkill::CheckInput()
 {
 	// Once the attack is finished
-	if (timer > player->currentState->duration * numSpins)
+	if (timer > fullSpinTime * numSpins)
 	{
 		if (player->IsUsingSkill())
 		{

--- a/Scripts/PlayerMovement/CircularAttackSkill.cpp
+++ b/Scripts/PlayerMovement/CircularAttackSkill.cpp
@@ -47,7 +47,7 @@ void CircularAttackSkill::Update()
 
 	timer += player->App->time->gameDeltaTime;
 
-	if (timer < fullSpinTime * numSpins)
+	if (timer < fullSpinTime * (numSpins + 1u))
 	{
 		UseSkill();
 	}
@@ -59,7 +59,7 @@ void CircularAttackSkill::Update()
 
 	CheckInput();
 
-	// MeleeSkill::Update() modified. Check when is time to enable the hitbox
+	// MeleeSkill::Update() modified. Check when it is time to enable the hitbox
 	if (!atatckStarted && !attackBoxTrigger->enabled && timer > hitDelay)
 	{
 		spinTimer = 0.0f;
@@ -87,7 +87,7 @@ void CircularAttackSkill::Update()
 
 void CircularAttackSkill::UseSkill()
 {
-	if (player->attackBoxTrigger != nullptr && !player->attackBoxTrigger->enabled && timer < player->currentState->duration * numSpins)
+	if (player->attackBoxTrigger != nullptr && !player->attackBoxTrigger->enabled && timer < player->currentState->duration * (numSpins + 1u))
 	{
 		// Update hitbox
 		player->attackBoxTrigger->SetBoxPosition(boxPosition.x, boxPosition.y, boxPosition.z);
@@ -154,7 +154,7 @@ void CircularAttackSkill::Reset()
 void CircularAttackSkill::CheckInput()
 {
 	// Once the attack is finished
-	if (timer > fullSpinTime * numSpins)
+	if (timer > fullSpinTime * (numSpins + 1u))
 	{
 		if (player->IsUsingSkill())
 		{

--- a/Scripts/PlayerMovement/CircularAttackSkill.cpp
+++ b/Scripts/PlayerMovement/CircularAttackSkill.cpp
@@ -29,8 +29,6 @@ void CircularAttackSkill::Start()
 {
 	fullSpinTime = duration;
 
-	LOG("Spin time: %f", fullSpinTime);
-
 	MeleeSkill::Start();
 
 	player->gameobject->transform->LookAtMouse();
@@ -48,8 +46,6 @@ void CircularAttackSkill::Update()
 	//BasicSkill::Update() modified
 
 	timer += player->App->time->gameDeltaTime;
-
-	LOG("TIMER: %f", timer);
 
 	if (timer < fullSpinTime * numSpins)
 	{
@@ -108,7 +104,6 @@ void CircularAttackSkill::UseSkill()
 		else
 		{
 			spinTimer += player->App->time->gameDeltaTime;
-			LOG("Spin Timer: %f", spinTimer);
 		}
 	}
 	else if(atatckStarted)

--- a/Scripts/PlayerMovement/CircularAttackSkill.h
+++ b/Scripts/PlayerMovement/CircularAttackSkill.h
@@ -22,12 +22,6 @@ public:
 	void Start() override;
 	void Update() override;
 
-	GameObject* mesh1 = nullptr;
-	GameObject* mesh2 = nullptr;
-	GameObject* mesh3 = nullptr;
-	GameObject* particles = nullptr;
-
-
 protected:
 	void UseSkill() override;
 	void Reset() override;
@@ -35,20 +29,26 @@ protected:
 	void CheckInput() override;
 	void MoveSpinning();
 
-private:
-	float fullSpinTime = 0.0f;	// Time it takes to the player to draw a full circle spinning (auto-calculated)
-	float spinTimer = 0.0f;		// Timer to check time performing a skill
+public:
+	// FX constant variables
+	GameObject* mesh1 = nullptr;
+	GameObject* mesh2 = nullptr;
+	GameObject* mesh3 = nullptr;
+	GameObject* particles = nullptr;
 
+private:
+	// Variables to customize 
 	unsigned numSpins = 4u;		// Number of complete spins the player will make before stoping
 
+	// Constant variables
+	float fullSpinTime = 0.0f;	// Time it takes to the player to draw a full circle spinning (auto-calculated)
+	float spinTimer = 0.0f;		// Timer to check time performing a skill
 	bool atatckStarted = false;
 
-	// Move variables
+	// Movement variables
 	std::vector<float3>path;
 	unsigned pathIndex = 0;
 	float moveTimer = 0.0f;
-
-
 };
 
 #endif __CircularAttackSkill_h__

--- a/Scripts/PlayerMovement/CircularAttackSkill.h
+++ b/Scripts/PlayerMovement/CircularAttackSkill.h
@@ -44,7 +44,6 @@ private:
 	bool atatckStarted = false;
 
 	// Move variables
-	float duration = 1.5f;
 	std::vector<float3>path;
 	unsigned pathIndex = 0;
 	float moveTimer = 0.0f;


### PR DESCRIPTION
Before:
- The circular attack got stuck some times until another input was given.
- After a chain attack, the time of the attack was higher than desired.

Now:
- The time of the attack is consistent.
- The time depends on the number of spins given. (By default 4).

To test:
*Make sure to rebuild PlayerMovement script before testing*
- Check that the circular attack spins 4 times every time (try using it while moving, after another skill, when in idle, etc.).
- You can use EnemiesTest2.sc3ne for testing.
