### PR TITLE
BUG/ persistance isn't deleted on game stop

### DIFF
--- a/Scripts/SkillTreeController/SkillTreeController.cpp
+++ b/Scripts/SkillTreeController/SkillTreeController.cpp
@@ -162,7 +162,8 @@ void SkillTreeController::Expose(ImGuiContext* context)
 
 	if (textureFiles.empty())
 	{
-		textureFiles = App->resManager->GetResourceNamesList(TYPE::TEXTURE, true);
+		if(App != nullptr)
+			textureFiles = App->resManager->GetResourceNamesList(TYPE::TEXTURE, true);
 	}
 
 	if (ImGui::Button("Refresh textures List"))

--- a/Source/Application.cpp
+++ b/Source/Application.cpp
@@ -24,7 +24,6 @@
 #include "Timer.h"
 #include "JSON.h"
 #include "Brofiler.h"
-#include "PlayerPrefs.h"
 
 using namespace std;
 #define MAX_REFRESH 3
@@ -149,6 +148,5 @@ bool Application::CleanUp()
 	{
 		ret = (*it)->CleanUp();
 	}
-	PlayerPrefs::DeleteAll(true);
 	return ret;
 }

--- a/Source/Application.cpp
+++ b/Source/Application.cpp
@@ -24,6 +24,7 @@
 #include "Timer.h"
 #include "JSON.h"
 #include "Brofiler.h"
+#include "PlayerPrefs.h"
 
 using namespace std;
 #define MAX_REFRESH 3
@@ -148,5 +149,6 @@ bool Application::CleanUp()
 	{
 		ret = (*it)->CleanUp();
 	}
+	PlayerPrefs::DeleteAll(true);
 	return ret;
 }

--- a/Source/ModuleScript.cpp
+++ b/Source/ModuleScript.cpp
@@ -80,8 +80,7 @@ bool ModuleScript::CleanUp()
 		SDL_Delay(100);
 	}
 #endif // !GAME_BUILD
-	PlayerPrefs::Save(); //Saves to Disk
-	PlayerPrefs::DeleteAll(); //Deletes All memory allocated
+	PlayerPrefs::DeleteAll(true); //Deletes All memory allocated and prefs files
 	return true;
 }
 

--- a/Source/PanelTime.cpp
+++ b/Source/PanelTime.cpp
@@ -11,6 +11,8 @@
 #include "PanelTime.h"
 #include "GameObject.h"
 
+#include "PlayerPrefs.h"
+
 #include "imgui.h"
 
 PanelTime::PanelTime()
@@ -54,6 +56,7 @@ void PanelTime::Draw()
 		{
 			App->time->StopGameClock();
 			App->scene->LoadTemporaryScene();
+			PlayerPrefs::DeleteAll(true);
 		}
 	}
 


### PR DESCRIPTION
Bug #800
**Before:** the persistence files we use to save info from level 1 to level 2 weren't deleted when the game was closed.
**Now:** the persistence files are deleted on **App close** and after hitting **stop**.

**To test 1:**
1. If you have persistence files inside "Game/Persistence" jump to step 3.
2. Else, download the following zip and extract the file in "Game/Persistence".
[Inventory.zip](https://github.com/fractal-puppy/Engine/files/3584829/Inventory.zip)

3. Start the app, load the first level (if not by default), hit play, hit stop.
4. If the Persistence folder is empty, then it works.

**To test 2:**
1. If you have persistence files inside "Game/Persistence" jump to step 3.
2. Else, download the following zip and extract the file in "Game/Persistence".
[Inventory.zip](https://github.com/fractal-puppy/Engine/files/3584829/Inventory.zip)

3. Start the app, load the first level (if not by default), hit play, close the app.
4. If the Persistence folder is empty, then it works.