### PR TITLE
BUG/Player Attack Multiple hit

### DIFF
--- a/Scripts/EnemyControllerScript/EnemyControllerScript.cpp
+++ b/Scripts/EnemyControllerScript/EnemyControllerScript.cpp
@@ -421,8 +421,17 @@ void EnemyControllerScript::OnTriggerEnter(GameObject* go)
 		}
 	}
 
-	if (go->tag == "PlayerHitBoxAttack")
+	if (go != lastHittedGO && go->tag == "PlayerHitBoxAttack")
 	{
 		TakeDamage(playerMovement->stats.strength * 0.1);
+		lastHittedGO = go;
+	}
+}
+
+void EnemyControllerScript::OnTriggerExit(GameObject* go)
+{
+	if (go == lastHittedGO)
+	{
+		lastHittedGO = nullptr;
 	}
 }

--- a/Scripts/EnemyControllerScript/EnemyControllerScript.h
+++ b/Scripts/EnemyControllerScript/EnemyControllerScript.h
@@ -58,6 +58,7 @@ public:
 	void LookAt2D(math::float3& position);
 
 	void OnTriggerEnter(GameObject* go) override;
+	void OnTriggerExit(GameObject* go) override;
 public:
 
 	bool isDead = false;
@@ -101,6 +102,7 @@ private:
 	float hitColorTimer = 0.f;
 	bool enemyHit = false;
 
+	GameObject* lastHittedGO = nullptr;			// Ptr to the last GO, with "PlayerHitBoxAttack", that triggered the enemy hitbox collision
 };
 
 extern "C" EnemyControllerScript_API Script* CreateScript();


### PR DESCRIPTION
[Bug #875](https://app.hacknplan.com/p/85404/kanban?categoryId=8&boardId=212215&taskId=875&tabId=basicinfo)

**Bug:** The player sometimes hits more than once with a single attack.
[Before gif](https://gyazo.com/5debf0b651c085a123f003e9d046628b)

**Fix:** Enemy checks onTriggerExit so the same hitbox isn't triggered without exiting before. For that, a new variable has been added to EnemyController that saves the GO with the last hitbox which made the enemy take damage. When the saved GO hitbox exits the collision, the variable is set to nullptr again.

[After gif](https://gyazo.com/9fab3ea3d56c4323c3609489f28b4f22)
It's a simple fix but seems to work, if it is found that doesn't work for every case more modification can be made, as adding a timer.

**To test:**
1. Recompile EnemyControllerScript.
2. Run the engine and load EnemyTest3.sc3ne.
3. Increase SpinEnemy health and hit play.
4. Check that the enemy only gets damage once for each attack. 