### PR TITLE
Bandolero hit material bug fixed

### DIFF
--- a/Scripts/EnemyControllerScript/EnemyControllerScript.cpp
+++ b/Scripts/EnemyControllerScript/EnemyControllerScript.cpp
@@ -65,6 +65,26 @@ void EnemyControllerScript::Awake()
 		LOG("Error: The enemy mesh couldn't be found.");
 	}
 
+	// Get hit material
+	std::vector<std::string> materials = App->resManager->GetResourceNamesList(TYPE::MATERIAL, true);
+	for (std::string matName : materials)
+	{
+		if (matName == hitMaterialName)
+		{
+			hitMaterial = (ResourceMaterial*)App->resManager->GetByName(matName.c_str(), TYPE::MATERIAL);
+		}
+	}
+	// Will only change first renderer material on hit
+	for (ComponentRenderer* renderer : myRenders)
+	{
+		defaultMaterials.push_back(renderer->material);
+	}
+
+	if (!hitMaterial)
+	{
+		hitMaterial = (ResourceMaterial*)App->resManager->GetByName(DEFAULTMAT, TYPE::MATERIAL);
+	}
+
 	// Look for player and his BBox
 	player = App->scene->FindGameObjectByTag(playerTag.c_str());
 	if (player == nullptr)
@@ -152,20 +172,6 @@ void EnemyControllerScript::Awake()
 			LOG("experienceController couldn't be found \n");
 		}
 	}
-	std::vector<std::string> materials = App->resManager->GetResourceNamesList(TYPE::MATERIAL, true);
-	for (std::string matName : materials)
-	{
-		if (matName == hitMaterialName)
-		{
-			hitMaterial = (ResourceMaterial*)App->resManager->GetByName(matName.c_str(), TYPE::MATERIAL);
-		}
-	}
-	// Will only change first renderer material on hit
-	defaultMaterial = GetMainRenderer()->material;
-	if (!hitMaterial)
-	{
-		hitMaterial = defaultMaterial;
-	}
 
 	GameObject* playerGO = App->scene->FindGameObjectByName("Player");
 	if (playerGO == nullptr)
@@ -235,8 +241,12 @@ void EnemyControllerScript::Update()
 	}
 	else if (enemyHit)
 	{
+		// Set default material back to all meshes
+		for (unsigned i = 0u; i < myRenders.size(); i++)
+		{
+			myRenders.at(i)->material = defaultMaterials.at(i);
+		}
 		enemyHit = false;
-		GetMainRenderer()->material = defaultMaterial;
 	}
 }
 
@@ -317,7 +327,11 @@ void EnemyControllerScript::TakeDamage(unsigned damage)
 		else
 		{
 			actualHealth -= damage;
-			GetMainRenderer()->material = hitMaterial;
+			// Set hit material to all enemy meshes
+			for (unsigned i = 0u; i < myRenders.size(); i++)
+			{
+				myRenders.at(i)->material = hitMaterial;
+			}
 			hitColorTimer = hitColorDuration;
 		}
 

--- a/Scripts/EnemyControllerScript/EnemyControllerScript.cpp
+++ b/Scripts/EnemyControllerScript/EnemyControllerScript.cpp
@@ -345,6 +345,17 @@ void EnemyControllerScript::TakeDamage(unsigned damage)
 			}
 			if (experienceController != nullptr)
 				experienceController->AddXP(experience);
+
+			// Disable hit boxes
+			hpBoxTrigger->Enable(false);
+			attackBoxTrigger->Enable(false);
+
+			// Unhighlight
+			if (myRenders.size() > 0u)
+			{
+				for (std::vector<ComponentRenderer*>::iterator it = myRenders.begin(); it != myRenders.end(); ++it)
+					(*it)->highlighted = false;
+			}
 		}
 		damageController->AddDamage(gameobject->transform, damage, 2);
 	}

--- a/Scripts/EnemyControllerScript/EnemyControllerScript.h
+++ b/Scripts/EnemyControllerScript/EnemyControllerScript.h
@@ -89,8 +89,8 @@ public:
 	ComponentBoxTrigger* attackBoxTrigger = nullptr;
 	ComponentBoxTrigger* playerHitBox = nullptr;
 
-	ResourceMaterial* hitMaterial = nullptr;
-	ResourceMaterial* defaultMaterial = nullptr;
+	ResourceMaterial* hitMaterial = nullptr;				// Material applied to all enemy meshes on hit
+	std::vector<ResourceMaterial*> defaultMaterials;		// Vector containing default materials of the enemy meshes
 
 	CombatAudioEvents* combataudioevents = nullptr;
 


### PR DESCRIPTION
[Bug #940](https://app.hacknplan.com/p/85404/kanban?categoryId=8&boardId=212215&taskId=940&tabId=basicinfo)
**Before:** Only the gun of the Bandolero turned red on hit.
**Now:** The gun and the Bandolero meshes turn red on hit.

To make this fix possible; the EnemyControllerScript saves a vector with all the meshes and their default materials found in the hierarchy of the enemy. So later, all of them are set in red and back with the default material.

**To test:**

1. Open the engine with The Graveyard scene.
2. Hit play.
3. Check that the Bandolero gun and body gets red on hit.
4. Check that the other skeletons still working.