### PR TITLE
Save Scene Window fixed

### DIFF
--- a/Source/FileExplorer.cpp
+++ b/Source/FileExplorer.cpp
@@ -40,7 +40,7 @@ bool FileExplorer::Open()
 		// List of files and directories box: [..] [Directories] [Files]
 		std::vector<std::string> files;
 		std::vector<std::string> dirs;
-		ImGui::BeginChild("Files", ImVec2(ImGui::GetWindowContentRegionWidth(), ImGui::GetWindowContentRegionMax().y - 120), true, ImGuiWindowFlags_HorizontalScrollbar);
+		ImGui::BeginChild("Files", ImVec2(ImGui::GetWindowContentRegionWidth(), ImGui::GetWindowContentRegionMax().y - 135), true, ImGuiWindowFlags_HorizontalScrollbar);
 		App->fsystem->ListFolderContent(path.c_str(), files, dirs);
 
 		ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(.0f, 0.5f));
@@ -87,7 +87,8 @@ bool FileExplorer::Open()
 		switch (currentOperation)
 		{
 		case MenuOperations::SAVE:
-			ImGui::Checkbox("Save selected game objects only", &saveSelected);
+			ImGui::Checkbox("Save selected game objects only", &saveSelected); 
+			ImGui::SameLine();
 			if (ImGui::Button("Save", ImVec2(100, 20)))
 			{
 				openFileExplorer = false;


### PR DESCRIPTION
[Bug 951](https://app.hacknplan.com/p/85404/kanban?categoryId=8&boardId=212215&taskId=951&tabId=basicinfo)
**Before:** It was hard to reach the buttons at the button of the window.
**Now:** Everything fits inside the window.

**To test:**
1. Open the engine.
2. Choose 'Save As...' inside the 'File' menu.
3. Check that the window size is good, and it is possible to reach the Save button without struggling.