### PR TITLE
Fixed a bug that made animation switch not work properly

### DIFF
--- a/Scripts/PlayerMovement/PlayerMovement.cpp
+++ b/Scripts/PlayerMovement/PlayerMovement.cpp
@@ -1052,12 +1052,22 @@ bool PlayerMovement::IsMoving() const
 	return (IsPressingMouse1() && !IsAttacking() && !IsMovingToAttack() && (!IsMovingToItem() || (IsMovingToItem() && stoppedGoingToItem)));
 }
 
+float PlayerMovement::DistPlayerToMouse() const
+{
+	math::float3 destinationPoint;
+	App->navigation->FindIntersectionPoint(gameobject->transform->position, destinationPoint);
+	float dist = destinationPoint.DistanceSq(gameobject->transform->position);
+	return dist;
+}
+
 bool PlayerMovement::IsPressingMouse1() const
 {
 	math::float3 temp;
 	return ((App->input->GetMouseButtonDown(1) == KEY_DOWN && !App->ui->UIHovered(true, false)) ||
 		(currentState->playerWalking && !currentState->playerWalkingToHit) ||
-		(App->input->GetMouseButtonDown(1) == KEY_REPEAT && !App->ui->UIHovered(true, false) && !App->scene->Intersects("PlayerMesh", false, temp) && currentState->playerWalking)); //right button, the player is still walking or movement button is pressed and can get close to mouse pos
+		(App->input->GetMouseButtonDown(1) == KEY_REPEAT && !App->ui->UIHovered(true, false) && !App->scene->Intersects("PlayerMesh", false, temp) && 
+		(currentState->playerWalking || DistPlayerToMouse() > closestDistToPlayer)));
+	//right button, the player is still walking or movement button is pressed and can get close to mouse pos
 }
 
 bool PlayerMovement::IsUsingRightClick() const

--- a/Scripts/PlayerMovement/PlayerMovement.cpp
+++ b/Scripts/PlayerMovement/PlayerMovement.cpp
@@ -1057,7 +1057,7 @@ bool PlayerMovement::IsPressingMouse1() const
 	math::float3 temp;
 	return ((App->input->GetMouseButtonDown(1) == KEY_DOWN && !App->ui->UIHovered(true, false)) ||
 		(currentState->playerWalking && !currentState->playerWalkingToHit) ||
-		(App->input->GetMouseButtonDown(1) == KEY_REPEAT && !App->ui->UIHovered(true, false) && !App->scene->Intersects("PlayerMesh", false, temp))); //right button, the player is still walking or movement button is pressed and can get close to mouse pos
+		(App->input->GetMouseButtonDown(1) == KEY_REPEAT && !App->ui->UIHovered(true, false) && !App->scene->Intersects("PlayerMesh", false, temp) && currentState->playerWalking)); //right button, the player is still walking or movement button is pressed and can get close to mouse pos
 }
 
 bool PlayerMovement::IsUsingRightClick() const

--- a/Scripts/PlayerMovement/PlayerMovement.h
+++ b/Scripts/PlayerMovement/PlayerMovement.h
@@ -207,6 +207,8 @@ private:
 
 	void ActivateHudCooldownMask(bool activate, unsigned first = HUD_BUTTON_Q, unsigned last = HUD_BUTTON_4);
 
+	float DistPlayerToMouse() const;
+
 	// Skills
 	void CreatePlayerSkills();
 
@@ -314,7 +316,7 @@ private:
 	Text* uiStrengthText = nullptr;
 	Text* uiManaText = nullptr;
 
-
+	float closestDistToPlayer = 31000.0f;
 	float hubCooldown[9]	  = { 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F };
 	float hubCooldownMax[9] = { 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F };
 	float hubCooldownTimer[9] = { 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F };

--- a/Scripts/PlayerMovement/PlayerStateWalk.cpp
+++ b/Scripts/PlayerMovement/PlayerStateWalk.cpp
@@ -53,12 +53,7 @@ void PlayerStateWalk::Update()
 		else
 		{
 			//clicked outside of the map, stop moving
-			playerWalking = false;
-			player->currentState = player->idle;
-			if (dustParticles)
-			{
-				dustParticles->SetActive(false);
-			}
+			toIdle = true;
 			return;
 		}
 	}
@@ -90,16 +85,13 @@ void PlayerStateWalk::Update()
 		}
 		else
 		{
-			playerWalking = false;
-			if (dustParticles)
-			{
-				dustParticles->SetActive(false);
-			}
+			toIdle = true;
+			return;
 		}
 	}	
 	else
 	{
-		player->currentState = player->idle;
+		toIdle = true;
 	}
 }
 
@@ -143,6 +135,17 @@ void PlayerStateWalk::CheckInput()
 			dustParticles->SetActive(false);
 		}
 	}*/
+	if (toIdle)
+	{
+		playerWalking = false;
+		player->currentState = player->idle;
+		if (dustParticles)
+		{
+			dustParticles->SetActive(false);
+		}
+		toIdle = false;
+		return;
+	}
 	if (player->IsUsingSkill() || player->IsAttacking())
 	{
 		player->currentState = (PlayerState*)player->attack;

--- a/Scripts/PlayerMovement/PlayerStateWalk.cpp
+++ b/Scripts/PlayerMovement/PlayerStateWalk.cpp
@@ -52,8 +52,8 @@ void PlayerStateWalk::Update()
 		}
 		else
 		{
-			//clicked outside of the map, stop moving
-			toIdle = true;
+			//distance 0 or clicked outside of the navmesh
+			playerWalking = false;
 			return;
 		}
 	}
@@ -85,18 +85,19 @@ void PlayerStateWalk::Update()
 		}
 		else
 		{
-			toIdle = true;
+			playerWalking = false;
 			return;
 		}
 	}	
 	else
 	{
-		toIdle = true;
+		playerWalking = false;
 	}
 }
 
 void PlayerStateWalk::Enter()
 {
+	playerWalking = true;
 	if (dustParticles)
 	{
 		dustParticles->SetActive(true);
@@ -135,15 +136,13 @@ void PlayerStateWalk::CheckInput()
 			dustParticles->SetActive(false);
 		}
 	}*/
-	if (toIdle)
+	if (!playerWalking)
 	{
-		playerWalking = false;
 		player->currentState = player->idle;
 		if (dustParticles)
 		{
 			dustParticles->SetActive(false);
 		}
-		toIdle = false;
 		return;
 	}
 	if (player->IsUsingSkill() || player->IsAttacking())

--- a/Scripts/PlayerMovement/PlayerStateWalk.h
+++ b/Scripts/PlayerMovement/PlayerStateWalk.h
@@ -21,6 +21,7 @@ public:
 	GameObject* dustParticles = nullptr;
 
 private:
+	bool toIdle = false;
 	float moveTimer = 0.0f;
 	
 };

--- a/Scripts/PlayerMovement/PlayerStateWalk.h
+++ b/Scripts/PlayerMovement/PlayerStateWalk.h
@@ -21,7 +21,6 @@ public:
 	GameObject* dustParticles = nullptr;
 
 private:
-	bool toIdle = false;
 	float moveTimer = 0.0f;
 	
 };

--- a/Scripts/PlayerMovement/PlayerStateWalkToHitEnemy.cpp
+++ b/Scripts/PlayerMovement/PlayerStateWalkToHitEnemy.cpp
@@ -56,7 +56,8 @@ void PlayerStateWalkToHitEnemy::Update()
 		{
 			//something went wrong, stop moving
 			LOG("Error walking to hit enemy");
-			toIdle = true;
+			playerWalking = false;
+			return;
 		}
 	}
 
@@ -77,7 +78,8 @@ void PlayerStateWalkToHitEnemy::Update()
 		else
 		{
 			LOG("Error walking to hit enemy along the way");
-			toIdle = true;
+			playerWalking = false;
+			return;
 		}
 	}
 	if (path.size() > 0)
@@ -111,13 +113,13 @@ void PlayerStateWalkToHitEnemy::Update()
 	}
 	else
 	{
-		toIdle = true;
+		playerWalking = false;
 	}
 }
 
 void PlayerStateWalkToHitEnemy::Enter()
 {
-	toIdle = toAttack = false;
+	toAttack = false;
 	if (dustParticles)
 	{
 		dustParticles->SetActive(true);
@@ -127,16 +129,14 @@ void PlayerStateWalkToHitEnemy::Enter()
 
 void PlayerStateWalkToHitEnemy::CheckInput()
 {
-	if (toIdle)
+	if (!playerWalking)
 	{
-		playerWalking = false;
 		playerWalkingToHit = false;
 		player->currentState = player->idle;
 		if (dustParticles)
 		{
 			dustParticles->SetActive(false);
 		}
-		toIdle = false;
 		return;
 	}
 	if (toAttack)

--- a/Scripts/PlayerMovement/PlayerStateWalkToHitEnemy.cpp
+++ b/Scripts/PlayerMovement/PlayerStateWalkToHitEnemy.cpp
@@ -56,14 +56,7 @@ void PlayerStateWalkToHitEnemy::Update()
 		{
 			//something went wrong, stop moving
 			LOG("Error walking to hit enemy");
-			playerWalking = false;
-			playerWalkingToHit = false;
-			player->currentState = player->idle;
-			if (dustParticles)
-			{
-				dustParticles->SetActive(false);
-			}
-			return;
+			toIdle = true;
 		}
 	}
 
@@ -84,14 +77,7 @@ void PlayerStateWalkToHitEnemy::Update()
 		else
 		{
 			LOG("Error walking to hit enemy along the way");
-			playerWalking = false;
-			playerWalkingToHit = false;
-			player->currentState = player->idle;
-			if (dustParticles)
-			{
-				dustParticles->SetActive(false);
-			}
-			return;
+			toIdle = true;
 		}
 	}
 	if (path.size() > 0)
@@ -120,49 +106,18 @@ void PlayerStateWalkToHitEnemy::Update()
 		}
 		else
 		{
-			//done walking, lets hit the enemy
-			//about the orientation of the player, in the chain attack state looks at the mouse automatically
-			player->enemyTargeted = true;
-			player->enemyTarget = walkingEnemyTargeted;
-
-			playerWalkingToHit = false;
-			playerWalking = false;
-
-			player->currentSkill = player->allSkills[SkillType::CHAIN]->skill;
-
-			SkillType skillType = SkillType::CHAIN;
-
-			//entering code
-			{
-
-				player->currentState = (PlayerState*)player->attack;
-
-				// Play skill animation
-				if (player->anim != nullptr)
-				{
-					player->anim->SendTriggerToStateMachine(player->currentSkill->animTrigger.c_str());
-				}
-
-				player->currentSkill->duration = player->anim->GetDurationFromClip();
-
-				player->UseSkill(skillType);
-				player->currentSkill->Start();
-
-			}
-			if (dustParticles)
-			{
-				dustParticles->SetActive(false);
-			}
+			toAttack = true;
 		}
 	}
 	else
 	{
-		player->currentState = player->idle;
+		toIdle = true;
 	}
 }
 
 void PlayerStateWalkToHitEnemy::Enter()
 {
+	toIdle = toAttack = false;
 	if (dustParticles)
 	{
 		dustParticles->SetActive(true);
@@ -172,6 +127,56 @@ void PlayerStateWalkToHitEnemy::Enter()
 
 void PlayerStateWalkToHitEnemy::CheckInput()
 {
+	if (toIdle)
+	{
+		playerWalking = false;
+		playerWalkingToHit = false;
+		player->currentState = player->idle;
+		if (dustParticles)
+		{
+			dustParticles->SetActive(false);
+		}
+		toIdle = false;
+		return;
+	}
+	if (toAttack)
+	{
+		//done walking, lets hit the enemy
+		//about the orientation of the player, in the chain attack state looks at the mouse automatically
+		player->enemyTargeted = true;
+		player->enemyTarget = walkingEnemyTargeted;
+
+		playerWalkingToHit = false;
+		playerWalking = false;
+
+		player->currentSkill = player->allSkills[SkillType::CHAIN]->skill;
+
+		SkillType skillType = SkillType::CHAIN;
+
+		//entering code
+		{
+
+			player->currentState = (PlayerState*)player->attack;
+
+			// Play skill animation
+			if (player->anim != nullptr)
+			{
+				player->anim->SendTriggerToStateMachine(player->currentSkill->animTrigger.c_str());
+			}
+
+			player->currentSkill->duration = player->anim->GetDurationFromClip();
+
+			player->UseSkill(skillType);
+			player->currentSkill->Start();
+
+		}
+		if (dustParticles)
+		{
+			dustParticles->SetActive(false);
+		}
+		toAttack = false;
+		return;
+	}
 	if (player->IsUsingSkill() || (player->IsAttacking()))
 	{
 		player->currentState = (PlayerState*)player->attack;

--- a/Scripts/PlayerMovement/PlayerStateWalkToHitEnemy.h
+++ b/Scripts/PlayerMovement/PlayerStateWalkToHitEnemy.h
@@ -24,6 +24,8 @@ private:
 	float moveTimer = 0.0f;
 	float defaultMaxDist = 10000.f;
 	float3 enemyPosition = float3(0.f, 0.f, 0.f);
+	bool toIdle = false;
+	bool toAttack = false;
 };
 
 #endif // __PLAYERSTATEWALKTOHIT_H_

--- a/Scripts/PlayerMovement/PlayerStateWalkToHitEnemy.h
+++ b/Scripts/PlayerMovement/PlayerStateWalkToHitEnemy.h
@@ -24,7 +24,6 @@ private:
 	float moveTimer = 0.0f;
 	float defaultMaxDist = 10000.f;
 	float3 enemyPosition = float3(0.f, 0.f, 0.f);
-	bool toIdle = false;
 	bool toAttack = false;
 };
 

--- a/Scripts/PlayerMovement/PlayerStateWalkToPickItem.cpp
+++ b/Scripts/PlayerMovement/PlayerStateWalkToPickItem.cpp
@@ -35,20 +35,6 @@ PlayerStateWalkToPickItem::~PlayerStateWalkToPickItem()
 {
 }
 
-void PlayerStateWalkToPickItem::StopAndSwitchToIdle()
-{
-	//stop going after the item
-	player->itemClicked = nullptr;
-	//stop particles
-	if (dustParticles)
-	{
-		dustParticles->SetActive(false);
-	}
-	//and set the player to idle
-	player->currentState = player->idle;
-	playerWalking = false;
-}
-
 void PlayerStateWalkToPickItem::Update()
 {
 	//check we really got the item in check
@@ -109,6 +95,7 @@ void PlayerStateWalkToPickItem::Update()
 
 void PlayerStateWalkToPickItem::Enter()
 {
+	done = false;
 	if (dustParticles)
 	{
 		dustParticles->SetActive(true);
@@ -118,6 +105,20 @@ void PlayerStateWalkToPickItem::Enter()
 
 void PlayerStateWalkToPickItem::CheckInput()
 {
+	if (done)
+	{
+		//stop going after the item
+		player->itemClicked = nullptr;
+		//stop particles
+		if (dustParticles)
+		{
+			dustParticles->SetActive(false);
+		}
+		player->currentState = player->idle;
+		playerWalking = false;
+		done = false;
+		return;
+	}
 	if (player->IsUsingSkill() || (player->IsAttacking()))
 	{
 		player->itemClicked = nullptr;

--- a/Scripts/PlayerMovement/PlayerStateWalkToPickItem.cpp
+++ b/Scripts/PlayerMovement/PlayerStateWalkToPickItem.cpp
@@ -79,23 +79,25 @@ void PlayerStateWalkToPickItem::Update()
 		{
 			//done walking, get the item
 			player->itemClicked->pickedUpViaPlayer = true;
-			StopAndSwitchToIdle();
+			playerWalking = false;
+			return;
 		}
 		else 
 		{
-			StopAndSwitchToIdle();
+			playerWalking = false;
+			return;
 		}
 	}
 	//no path, stop
 	else
 	{
-		StopAndSwitchToIdle();
+		playerWalking = false;
+		return;
 	}
 }
 
 void PlayerStateWalkToPickItem::Enter()
 {
-	done = false;
 	if (dustParticles)
 	{
 		dustParticles->SetActive(true);
@@ -105,7 +107,7 @@ void PlayerStateWalkToPickItem::Enter()
 
 void PlayerStateWalkToPickItem::CheckInput()
 {
-	if (done)
+	if (!playerWalking)
 	{
 		//stop going after the item
 		player->itemClicked = nullptr;
@@ -116,7 +118,6 @@ void PlayerStateWalkToPickItem::CheckInput()
 		}
 		player->currentState = player->idle;
 		playerWalking = false;
-		done = false;
 		return;
 	}
 	if (player->IsUsingSkill() || (player->IsAttacking()))

--- a/Scripts/PlayerMovement/PlayerStateWalkToPickItem.h
+++ b/Scripts/PlayerMovement/PlayerStateWalkToPickItem.h
@@ -20,8 +20,9 @@ public:
 	GameObject* dustParticles = nullptr;
 
 private:
-	void StopAndSwitchToIdle();
+	inline void StopAndSwitchToIdle() { done = true; }
 private:
+	bool done = false;
 	float moveTimer = 0.0f;
 	float defaultMaxDist = 10000.f;
 	float3 itemPosition = float3(0.f, 0.f, 0.f);

--- a/Scripts/PlayerMovement/PlayerStateWalkToPickItem.h
+++ b/Scripts/PlayerMovement/PlayerStateWalkToPickItem.h
@@ -20,9 +20,8 @@ public:
 	GameObject* dustParticles = nullptr;
 
 private:
-	inline void StopAndSwitchToIdle() { done = true; }
+	//functions
 private:
-	bool done = false;
 	float moveTimer = 0.0f;
 	float defaultMaxDist = 10000.f;
 	float3 itemPosition = float3(0.f, 0.f, 0.f);

--- a/Source/ModuleNavigation.cpp
+++ b/Source/ModuleNavigation.cpp
@@ -1480,6 +1480,10 @@ bool ModuleNavigation::FindPath(math::float3 start, math::float3 end, std::vecto
 				type = PathFindType::NODODGE;
 				done = false;
 			}
+			if (afterPathDistance == 0.f)
+			{
+				return false;
+			}
 			else if (logDebugPathing)
 			{
 				std::stringstream s;


### PR DESCRIPTION
To test:
- load the graveyard scene
- check that after picking up an item, the walking animation stops
- check that when clicking on an enemy, the switch between walking and attacking works
- check that when clicking outside of the navmesh or clicking far away, the player makes like its going to try to go but stops in idle position.