### PR TITLE
Character does not compute new path while hovering ui

### DIFF
--- a/Scripts/PlayerMovement/PlayerMovement.cpp
+++ b/Scripts/PlayerMovement/PlayerMovement.cpp
@@ -1209,8 +1209,8 @@ bool PlayerMovement::IsAttacking() const
 	}
 	//and finally if enemy is on attack range
 	if (App->scene->enemyHovered.object != nullptr &&
-		(App->input->GetMouseButtonDown(1) == KEY_REPEAT && !App->ui->UIHovered(false, true) ||
-			App->input->GetMouseButtonDown(1) == KEY_DOWN && !App->ui->UIHovered(false, true)) &&
+		(App->input->GetMouseButtonDown(1) == KEY_REPEAT && !App->ui->UIHovered(true, false) ||
+			App->input->GetMouseButtonDown(1) == KEY_DOWN && !App->ui->UIHovered(true, false)) &&
 		Dist <= basicAttackRange)
 	{
 		return true;
@@ -1223,8 +1223,8 @@ bool PlayerMovement::IsMovingToAttack() const
 
 	if (App->scene->enemyHovered.object != nullptr && App->scene->enemyHovered.health > 0 &&
 		!App->input->IsKeyPressed(SDL_SCANCODE_LSHIFT) == KEY_DOWN &&
-		(App->input->GetMouseButtonDown(1) == KEY_REPEAT && !App->ui->UIHovered(false, true) ||
-			App->input->GetMouseButtonDown(1) == KEY_DOWN && !App->ui->UIHovered(false, true)) &&
+		(App->input->GetMouseButtonDown(1) == KEY_REPEAT && !App->ui->UIHovered(true, false) ||
+			App->input->GetMouseButtonDown(1) == KEY_DOWN && !App->ui->UIHovered(true, false)) &&
 		Distance(gameobject->transform->position, App->scene->enemyHovered.object->transform->position) > basicAttackRange)
 	{
 		return true;
@@ -1248,9 +1248,10 @@ float PlayerMovement::DistPlayerToMouse() const
 bool PlayerMovement::IsPressingMouse1() const
 {
 	math::float3 temp;
-	return ((App->input->GetMouseButtonDown(1) == KEY_DOWN && !App->ui->UIHovered(false, true)) ||
+	return (
+		(App->input->GetMouseButtonDown(1) == KEY_DOWN && !App->ui->UIHovered(true, false)) ||
 		(currentState->playerWalking && !currentState->playerWalkingToHit) ||
-		(App->input->GetMouseButtonDown(1) == KEY_REPEAT && !App->ui->UIHovered(true, false) && !App->scene->Intersects("PlayerMesh", false, temp) && 
+		(App->input->GetMouseButtonDown(1) == KEY_REPEAT && !App->ui->UIHovered(true, false) && !App->scene->Intersects("PlayerMesh", false, temp) &&
 		(currentState->playerWalking || DistPlayerToMouse() > closestDistToPlayer)));
 }
 

--- a/Scripts/PlayerMovement/PlayerStateWalk.cpp
+++ b/Scripts/PlayerMovement/PlayerStateWalk.cpp
@@ -7,6 +7,7 @@
 #include "ModuleNavigation.h"
 #include "ModuleTime.h"
 #include "ModuleWindow.h"
+#include "ModuleUI.h"
 #include "GameObject.h"
 #include "ComponentTransform.h"
 #include "ComponentAnimation.h"
@@ -38,8 +39,8 @@ PlayerStateWalk::~PlayerStateWalk()
 void PlayerStateWalk::Update()
 {
 	math:float2 mouse((float*)&player->App->input->GetMousePosition());
-	if (player->App->input->GetMouseButtonDown(1) == KEY_DOWN 
-		|| player->App->input->GetMouseButtonDown(1) == KEY_REPEAT)
+	if ((player->App->input->GetMouseButtonDown(1) == KEY_DOWN 
+		|| player->App->input->GetMouseButtonDown(1) == KEY_REPEAT) && !player->App->ui->UIHovered(true,false))
 	{
 		moveTimer = 0.0f;
 		math::float3 intPos(0.f, 0.f, 0.f);


### PR DESCRIPTION
Objective:
While the character is moving:

- If you click on a ui button (that is covering a walkable spot), the character does not move towards that spot

- If you maintain the mouse button pressed and hover a ui button, the character stops at the last position not hovered

Test:
- Hover and click ui buttons while the character is moving