### PR TITLE
Activate desktop fullscreen mode

### DIFF
--- a/Source/ModuleWindow.cpp
+++ b/Source/ModuleWindow.cpp
@@ -51,6 +51,7 @@ bool ModuleWindow::Init(JSON * config)
 		}
 #else
 		//fullscreen = true;
+		fullscreen_desktop = true;
 #endif
 		//Create window
 		Uint32 flags = SDL_WINDOW_SHOWN |  SDL_WINDOW_OPENGL;


### PR DESCRIPTION
Game get displayed in full screen properly in Game Mode Release. 

Test:
Open the game in GameMode (Release) and check that is properly displayed (fullscreen and centered)