### PR TITLE
Spin enemy rotation fix

### DIFF
--- a/Scripts/EnemyControllerScript/EnemyControllerScript.h
+++ b/Scripts/EnemyControllerScript/EnemyControllerScript.h
@@ -70,6 +70,7 @@ public:
 public:
 
 	bool isDead = false;
+	bool hasFreeRotation = false;
 	GameObject* player = nullptr;
 	PlayerMovement* playerMovement = nullptr;
 	std::string playerTag = "Player";

--- a/Scripts/SpinToWinEnemyAI/EnemyStateAttackSpin.cpp
+++ b/Scripts/SpinToWinEnemyAI/EnemyStateAttackSpin.cpp
@@ -77,6 +77,7 @@ void EnemyStateAttackSpin::Update()
 
 void EnemyStateAttackSpin::Enter()
 {
+	enemy->enemyController->Stop();
 }
 
 void EnemyStateAttackSpin::Exit()
@@ -87,7 +88,7 @@ void EnemyStateAttackSpin::Exit()
 	}
 }
 
-void EnemyStateAttackSpin::Attack() //Split into SPIN or normal ATTACK
+void EnemyStateAttackSpin::Attack() //Splited into SPIN or normal ATTACK
 {
 
 	if ((!LessThanHalfHP() || lcg.Float() < 0.25 || isOnCooldown) && !spinning) //Normal attack
@@ -156,6 +157,7 @@ void EnemyStateAttackSpin::ChangeToSpinMaterial(MATERIALTYPE type) const
 
 void EnemyStateAttackSpin::EnableSpin()
 {
+	enemy->gameobject->transform->lockLookAt = true;
 	spinning = true;
 	PunchFX(true);
 	attacked = false;
@@ -164,6 +166,7 @@ void EnemyStateAttackSpin::EnableSpin()
 
 void EnemyStateAttackSpin::DisableSpin()
 {
+	enemy->gameobject->transform->lockLookAt = false;
 	PunchFX(false);
 	enemyRenderer->avoidSkinning = false;
 	spinOff->SetActive(false);

--- a/Source/ComponentTransform.cpp
+++ b/Source/ComponentTransform.cpp
@@ -329,6 +329,7 @@ ENGINE_API void ComponentTransform::Rotate(math::float3 rot)
 
 ENGINE_API void ComponentTransform::LookAt(const math::float3& targetPosition)
 {
+	if (lockLookAt) return;
 	math::float3 direction = (targetPosition - GetGlobalPosition());
 	math::Quat newRotation = GetGlobalRotation().LookAt(float3::unitZ, direction.Normalized(), float3::unitY, float3::unitY);	
 	SetGlobalRotation(newRotation);
@@ -336,6 +337,7 @@ ENGINE_API void ComponentTransform::LookAt(const math::float3& targetPosition)
 
 void ComponentTransform::LookAtLocal(const math::float3& localTarget)
 {
+	if (lockLookAt) return;
 	math::float3 direction = (localTarget - position);
 	math::Quat newRotation = rotation.LookAt(float3::unitZ, direction.Normalized(), float3::unitY, float3::unitY);
 	SetRotation(newRotation);

--- a/Source/ComponentTransform.h
+++ b/Source/ComponentTransform.h
@@ -79,6 +79,8 @@ public:
 	math::float3 right = math::float3::zero;
 	math::float3 front = math::float3::zero;
 
+	bool lockLookAt = false;
+
 private:
 	math::float3 old_position = math::float3::zero;
 	math::float3 old_euler = math::float3::zero;


### PR DESCRIPTION
# Le Fix
- Spin Enemy now spins properly while using Detour Crowd for movement
- The spin enemy doesn't slide anymore when hitting the player

# Le Test
- Open the graveyard scene and test that the spin enemy located at the end of the level spins properly and does not slide.