### PR TITLE
Amount disappear on Drag&Drop in-place 

### DIFF
--- a/Scripts/InventoryScript/InventoryScript.cpp
+++ b/Scripts/InventoryScript/InventoryScript.cpp
@@ -510,6 +510,18 @@ void InventoryScript::Update()
 
 
 					}
+					else
+					{
+						for (int z = 0; z < items.size(); ++z)
+						{
+							if (items[z].second == i)
+							{
+								int quantity = GetCurrentQuantity(*items[z].first);
+								ManageConsumableItemsQuantityText(*items[z].first, quantity);
+								continue;
+							}
+						}
+					}
 					break;
 				}
 			}


### PR DESCRIPTION
The number displaying the number of potions disappeared when you drag and drop a consumable in place on the inventory.

Before:
![NETA_self_drag_drop_amount](https://user-images.githubusercontent.com/26639060/66594453-7fe8d600-eb99-11e9-8706-7b003121eba8.gif)

After:
![NETA_self_drag_drop_amount_solved](https://user-images.githubusercontent.com/26639060/66594464-8414f380-eb99-11e9-8716-04e307be1eab.gif)

Test:
- pick up a consumable
- open inventory
- drag and drop the item to the same slot
- after dropping the item, the amount must be displayed.
