### PR TITLE
Ensure side menus are closed

### DIFF
--- a/Scripts/GameLoop/LoopStatePaused.cpp
+++ b/Scripts/GameLoop/LoopStatePaused.cpp
@@ -7,6 +7,9 @@
 #include "GameObject.h"
 #include "ComponentButton.h"
 
+#include "Math/float2.h"
+#include "ComponentTransform2D.h"
+
 LoopStatePaused::LoopStatePaused(GameLoop* GL) : LoopState(GL)
 {
 }
@@ -20,6 +23,13 @@ void LoopStatePaused::Enter()
 {
 	gLoop->App->time->gameTimeScale = 0.0F;
 	if (gLoop->pauseMenuGO) gLoop->pauseMenuGO->SetActive(true);
+	
+	gLoop->inventoryMenuGO->SetActive(false);
+	gLoop->skillsMenuGO->SetActive(false);
+	gLoop->playerMenuGO->SetActive(false);
+
+	gLoop->inventoryButton->rectTransform->setPosition(math::float2(-50, gLoop->inventoryButton->rectTransform->getPosition().y));
+	gLoop->skillsButton->rectTransform->setPosition(math::float2(-50, gLoop->skillsButton->rectTransform->getPosition().y));
 }
 
 void LoopStatePaused::Update()


### PR DESCRIPTION
Raising the pause menu while a side panel (inventory/skills) is open, closes the side panel.

![neta_1039](https://user-images.githubusercontent.com/26639060/66652285-ac523000-ec35-11e9-974b-a2cc62f436e8.gif)

Test:
- Open the inventory/skills panel
- Pause the game (the inventory/skills panel should close and the pause menu should appear)