### PR TITLE
Fixed targeting of the skeletons when the boss was switching phases

### DIFF
--- a/Scripts/BossBehaviourScript/BossStateActivated.cpp
+++ b/Scripts/BossBehaviourScript/BossStateActivated.cpp
@@ -48,9 +48,13 @@ void BossStateActivated::Update()
 		boss->enemyController->SetPosition(newPosition);
 	}
 	//while getting to the ground, she cannot be attacked
-	boss->App->scene->enemyHovered.object = nullptr;
-	boss->App->scene->enemyHovered.health = 0;
-	boss->App->scene->enemyHovered.triggerboxMinWidth = 0;
+	//but only if the target is the boss, not an skeleton and stuff
+	if (boss->App->scene->enemyHovered.object == boss->gameobject)
+	{
+		boss->App->scene->enemyHovered.object = nullptr;
+		boss->App->scene->enemyHovered.health = 0;
+		boss->App->scene->enemyHovered.triggerboxMinWidth = 0;
+	}
 }
 
 void BossStateActivated::Enter()

--- a/Scripts/BossBehaviourScript/BossStateInterPhase.cpp
+++ b/Scripts/BossBehaviourScript/BossStateInterPhase.cpp
@@ -33,9 +33,13 @@ void BossStateInterPhase::HandleIA()
 void BossStateInterPhase::Update()
 {
 	//while getting to the ground, she cannot be attacked
-	boss->App->scene->enemyHovered.object = nullptr;
-	boss->App->scene->enemyHovered.health = 0;
-	boss->App->scene->enemyHovered.triggerboxMinWidth = 0;
+	//but only if the target is the boss, not an skeleton and stuff
+	if (boss->App->scene->enemyHovered.object == boss->gameobject)
+	{
+		boss->App->scene->enemyHovered.object = nullptr;
+		boss->App->scene->enemyHovered.health = 0;
+		boss->App->scene->enemyHovered.triggerboxMinWidth = 0;
+	}
 	switch (ipState)
 	{
 	case IpState::None:


### PR DESCRIPTION
There was a bug that while boss was in a transition state, player could not kill skeletons.
to test:
- Check that now while boss is floating going down at the beggining you can kill enemies.
- Check what when the boss is flying at the beggining of 2nd phase you can easily attack enemies.