### PR TITLE
BUG/ Dust particles on walking to item pick up

### DIFF
--- a/Scripts/PlayerMovement/PlayerMovement.cpp
+++ b/Scripts/PlayerMovement/PlayerMovement.cpp
@@ -753,11 +753,6 @@ void PlayerMovement::Start()
 
 void PlayerMovement::Update()
 {
-	if (currentState == walk)
-		walk->dustParticles->SetActive(true);			
-	else
-		walk->dustParticles->SetActive(false);
-
 	if (App->time->gameTimeScale == 0) return;
 
 	deltatime = App->time->gameDeltaTime;
@@ -1611,7 +1606,7 @@ void PlayerMovement::ResetCooldown(unsigned int hubButtonID)
 	}
 }
 
-void PlayerMovement::CheckStates(PlayerState * previous, PlayerState * current)
+void PlayerMovement::CheckStates(PlayerState* previous, PlayerState* current)
 {
 	if (previous != current)
 	{
@@ -1626,6 +1621,12 @@ void PlayerMovement::CheckStates(PlayerState * previous, PlayerState * current)
 		}
 
 		current->duration = anim->GetDurationFromClip();
+
+		// Set walk particles active when new state has walking
+		if (current == walk || current == walkToPickItem || current == walkToHit)
+			walk->dustParticles->SetActive(true);
+		else
+			walk->dustParticles->SetActive(false);
 	}
 }
 


### PR DESCRIPTION
[Bug #999](https://app.hacknplan.com/p/85404/kanban?categoryId=0&boardId=265751&taskId=999&tabId=basicinfo)

Before: If you walked towards an item or an enemy by clicking on it, the dust particles didn't show up.

Now: They show up.

**To test:**
- Play the first level, click on an item and check if the dust particles appear.
- The same by clicking on an enemy.