### PR TITLE
FIX - Rotation bug on Spaw Prefab

### DIFF
--- a/Scripts/PlayerMovement/PlayerMovement.cpp
+++ b/Scripts/PlayerMovement/PlayerMovement.cpp
@@ -250,7 +250,7 @@ void PlayerMovement::CreatePlayerSkills()
 		rain->decal->SetActive(false);
 	}
 	GameObject* machete = App->scene->Spawn("MacheteRain");
-	if (machete)
+	if (machete && rain->decal)
 	{
 		rain->decalOriginalColor = ((ComponentRenderer*)rain->decal->GetComponent<ComponentRenderer>())->material->diffuseColor;
 		rain->decalMaterial = ((ComponentRenderer*)rain->decal->GetComponent<ComponentRenderer>())->material;

--- a/Source/ComponentTransform.cpp
+++ b/Source/ComponentTransform.cpp
@@ -376,6 +376,14 @@ void ComponentTransform::Align(const math::float3 & targetFront)
 	SetRotation(rotation.Mul(newRotation));
 }
 
+void ComponentTransform::UpdateTransformOnSpawn()
+{
+	LOG("Transform Awake");
+	rotation = math::Quat::FromEulerXYZ(math::DegToRad(eulerRotation.x), math::DegToRad(eulerRotation.y), math::DegToRad(eulerRotation.z));
+	UpdateTransform();
+	gameobject->movedFlag = true;
+}
+
 void ComponentTransform::Save(JSON_value* value) const
 {
 	Component::Save(value);

--- a/Source/ComponentTransform.h
+++ b/Source/ComponentTransform.h
@@ -46,7 +46,7 @@ public:
 	ENGINE_API void LookAtLocal(const math::float3& localTarget);
 	ENGINE_API void LookAtMouse();
 	ENGINE_API void Align(const math::float3& target);
-
+	void UpdateTransformOnSpawn();
 
 	void Save(JSON_value* value) const override;
 	void Load(JSON_value* value) override;

--- a/Source/ModuleScene.cpp
+++ b/Source/ModuleScene.cpp
@@ -1735,6 +1735,8 @@ GameObject* ModuleScene::Spawn(const char * name, GameObject * parent, math::flo
 			}
 		}
 	}
+	if (instance->transform)
+		instance->transform->UpdateTransformOnSpawn();
 	return instance;
 }
 


### PR DESCRIPTION
Detected & fixed an issue with the rotation when a prefab is spawned.

To try:

Launch the machete rain skill. The decal machete should appear vertical instead horizontal