### PR TITLE
Bug/inventory loss at level2

### DIFF
--- a/Scripts/GameLoop/LoopStatePlaying.cpp
+++ b/Scripts/GameLoop/LoopStatePlaying.cpp
@@ -28,6 +28,15 @@ LoopStatePlaying::~LoopStatePlaying()
 {
 }
 
+void LoopStatePlaying::SavePlayerData()
+{
+	gLoop->inventoryScript->SaveInventory();
+	gLoop->skillTreeScript->SaveSkillTree();
+	gLoop->experienceScript->SaveExperience();
+	gLoop->equipPopUpScript->SavePopUp();
+	gLoop->playerScript->SavePlayerStats();
+}
+
 void LoopStatePlaying::Update()
 {
 	if (gLoop->inventoryButton->IsPressed() && !gLoop->inventoryMenuGO->isActive())	gLoop->menuButtonsSound->Play();
@@ -69,11 +78,7 @@ void LoopStatePlaying::Update()
 
 		if (gLoop->gameScene == GameScene::CEMENTERY || gLoop->gameScene == GameScene::TEMPLE)
 		{
-			gLoop->inventoryScript->SaveInventory();
-			gLoop->skillTreeScript->SaveSkillTree();
-			gLoop->experienceScript->SaveExperience();
-			gLoop->equipPopUpScript->SavePopUp();
-			gLoop->playerScript->SavePlayerStats();
+			SavePlayerData();
 		}
 		
 
@@ -93,6 +98,12 @@ void LoopStatePlaying::Update()
 		{
 			Win();
 		}
+	}
+	//extra case to ensure we save the player info
+	if (gLoop->playerScript->FinishingLevel0)
+	{
+		SavePlayerData();
+		gLoop->playerScript->FinishingLevel0 = false;
 	}
 }
 

--- a/Scripts/GameLoop/LoopStatePlaying.h
+++ b/Scripts/GameLoop/LoopStatePlaying.h
@@ -13,7 +13,7 @@ public:
 	virtual ~LoopStatePlaying();
 	
 	void Update() override;
-
+	void SavePlayerData();
 
 private:
 	void Win();

--- a/Scripts/PlayerMovement/PlayerMovement.h
+++ b/Scripts/PlayerMovement/PlayerMovement.h
@@ -251,6 +251,7 @@ private:
 	void InitializeUIStatsObjects();
 	void InitializeAudioObjects();
 public:
+	bool FinishingLevel0 = false;
 	bool ThirdStageBoss = false;
 
 	bool isPlayerDead = false;

--- a/Scripts/PlayerMovement/PlayerStateAutoWalk.cpp
+++ b/Scripts/PlayerMovement/PlayerStateAutoWalk.cpp
@@ -79,6 +79,7 @@ void PlayerStateAutoWalk::Update()
 
 void PlayerStateAutoWalk::Enter()
 {
+	player->FinishingLevel0 = true;
 	//Deactivate camera script
 	player->playerCamera->GetComponent<CameraController>()->Enable(false);
 


### PR DESCRIPTION
Since this bug was reported via play tests and I could not really reproduce it myself, now the inventory and player info is saved twice just in case 1 time it failed