### PR TITLE
BUG/ deleted level 2 extra items + added pants + max level fix

### DIFF
--- a/Game/Assets/Prefabs/GameHUB.pr3fab
+++ b/Game/Assets/Prefabs/GameHUB.pr3fab
@@ -5226,7 +5226,7 @@
                     "script": "ExperienceController",
                     "scriptInfo": {
                         "timeShowing": 3.0,
-                        "numLevels": 6,
+                        "numLevels": 7,
                         "0": 20,
                         "1": 180,
                         "2": 300,

--- a/Game/Assets/Scenes/Level2-ForbiddenTemple.sc3ne.meta
+++ b/Game/Assets/Scenes/Level2-ForbiddenTemple.sc3ne.meta
@@ -1,7 +1,7 @@
 {
     "Scene": {
         "metaVersion": 2,
-        "timeCreated": 1573033420,
+        "timeCreated": 1567941234,
         "GUID": 340679392,
         "Name": "Level2-ForbiddenTemple",
         "File": "Assets/Scenes/Level2-ForbiddenTemple.sc3ne",


### PR DESCRIPTION
Bugs fixed:
- Extra items at the start of level 2 have been deleted.
- Added golden pants because there weren't any.
- Now max level is 7 that enables you to unlock every skill.